### PR TITLE
Fix: Resolve 'worldRotationDegrees' unresolved reference in Perspecti…

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/domain/UpdateStateUseCase.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/domain/UpdateStateUseCase.kt
@@ -78,6 +78,7 @@ class UpdateStateUseCase @Inject constructor(
 
         val perspectiveMatrix = Perspective.createPerspectiveMatrix(
             currentOrientation = stateWithCoercedPan.currentOrientation,
+            worldRotationDegrees = stateWithCoercedPan.worldRotationDegrees,
             camera = camera,
             lift = 0f,
             applyPitch = isPitchApplied
@@ -94,6 +95,7 @@ class UpdateStateUseCase @Inject constructor(
 
         val railPerspectiveMatrix = Perspective.createPerspectiveMatrix(
             currentOrientation = stateWithCoercedPan.currentOrientation,
+            worldRotationDegrees = stateWithCoercedPan.worldRotationDegrees,
             camera = camera,
             lift = railLiftAmount,
             applyPitch = isPitchApplied
@@ -103,6 +105,7 @@ class UpdateStateUseCase @Inject constructor(
 
         val flatPerspectiveMatrix = Perspective.createPerspectiveMatrix(
             currentOrientation = stateWithCoercedPan.currentOrientation,
+            worldRotationDegrees = stateWithCoercedPan.worldRotationDegrees,
             camera = camera,
             applyPitch = false
         )
@@ -110,6 +113,7 @@ class UpdateStateUseCase @Inject constructor(
 
         val logicalPlanePerspectiveMatrix = Perspective.createPerspectiveMatrix(
             currentOrientation = stateWithCoercedPan.currentOrientation,
+            worldRotationDegrees = stateWithCoercedPan.worldRotationDegrees,
             camera = camera,
             applyPitch = false
         )
@@ -120,6 +124,7 @@ class UpdateStateUseCase @Inject constructor(
         val sizeCalculationPerspectiveMatrix =
             Perspective.createPerspectiveMatrix(
                 currentOrientation = state.currentOrientation,
+                worldRotationDegrees = state.worldRotationDegrees,
                 camera = camera,
                 lift = 0f,
                 applyPitch = isPitchApplied

--- a/app/src/main/java/com/hereliesaz/cuedetat/view/model/Perspective.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/view/model/Perspective.kt
@@ -25,6 +25,7 @@ object Perspective {
      */
     fun createPerspectiveMatrix(
         currentOrientation: FullOrientation,
+        worldRotationDegrees: Float,
         camera: Camera,
         lift: Float = 0f,
         applyPitch: Boolean = true,


### PR DESCRIPTION
…ve.kt

The `createPerspectiveMatrix` function in `Perspective.kt` was using the `worldRotationDegrees` variable without it being defined in the function's scope, leading to a compilation error.

This commit fixes the issue by:
1.  Adding `worldRotationDegrees: Float` as a parameter to the `createPerspectiveMatrix` function, as was intended by its documentation.
2.  Updating all call sites of this function in `UpdateStateUseCase.kt` to pass the required `worldRotationDegrees` value from the application state.