### PR TITLE
Fix: Center tilt pivot point on the table

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/view/model/Perspective.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/view/model/Perspective.kt
@@ -30,9 +30,7 @@ object Perspective {
         val matrix = Matrix()
         camera.save()
 
-        // The camera is at a fixed Z distance.
-        camera.setLocation(0f, 0f, -32f)
-
+        // The camera's Z position is translated after rotation to pivot around the table's center.
         if (applyPitch) {
             val physicalPitch = currentOrientation.pitch
             val physicalMaxPitch = 75f
@@ -75,10 +73,8 @@ object Perspective {
             camera.rotateX(visualPitch.coerceIn(-90f, 90f))
         }
 
-        // Translate must happen AFTER rotation to function as a "lift".
-        if (lift != 0f) {
-            camera.translate(0f, lift, 0f)
-        }
+        // Translate must happen AFTER rotation to function as a "lift" and to set camera distance.
+        camera.translate(0f, lift, -32f)
 
         camera.getMatrix(matrix)
         camera.restore()


### PR DESCRIPTION
The previous implementation set the camera's location before applying the tilt rotation. This caused the rotation to pivot around the camera's position in space, which was far from the table surface, leading to a disorienting "swinging" effect.

This change modifies the order of operations in `Perspective.kt`. The camera's Z-axis translation is now applied *after* the `rotateX` call. This makes the rotation pivot around the world origin (0,0,0), which corresponds to the center of the table.

Note: The project's unit tests are currently failing to compile due to an unrelated issue in `AzNavRailMenu.kt`. I have confirmed that this issue existed before my changes. I was therefore unable to run the tests to verify this change.

## Summary by Sourcery

Fix camera pivot to rotate around table center by applying Z translation after rotation.

Bug Fixes:
- Correct camera pivot by moving Z-axis translation after the X-axis rotation to eliminate the swinging effect around a distant point.

Enhancements:
- Combine lift and camera distance translation into a single translate call after rotation.

Chores:
- Tests are currently failing to compile due to an unrelated pre-existing issue in AzNavRailMenu.kt, so they were not run.