### PR TITLE
Fix backup and data extraction rules config

### DIFF
--- a/.github/workflows/android_debug_apk_release.yml
+++ b/.github/workflows/android_debug_apk_release.yml
@@ -84,6 +84,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: false
+          dependency-graph: disabled
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -11,7 +11,7 @@
     <include domain="sharedpref" path="."/>
 
     <!-- Exclude potentially sensitive or unnecessary data as product requirements are not provided -->
-    <!-- <exclude domain="root" path="."/>
+    <exclude domain="root" path="."/>
     <exclude domain="database" path="."/>
-    <exclude domain="external" path="."/> -->
+    <exclude domain="external" path="."/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -10,17 +10,17 @@
         <include domain="sharedpref" path="."/>
 
         <!-- Exclude potentially sensitive or unnecessary data as product requirements are not provided -->
-        <!-- <exclude domain="root" path="."/>
+        <exclude domain="root" path="."/>
         <exclude domain="database" path="."/>
-        <exclude domain="external" path="."/> -->
+        <exclude domain="external" path="."/>
     </cloud-backup>
     <device-transfer>
         <include domain="file" path="datastore/settings.preferences_pb"/>
         <include domain="sharedpref" path="."/>
 
         <!-- Exclude potentially sensitive or unnecessary data as product requirements are not provided -->
-        <!-- <exclude domain="root" path="."/>
+        <exclude domain="root" path="."/>
         <exclude domain="database" path="."/>
-        <exclude domain="external" path="."/> -->
+        <exclude domain="external" path="."/>
     </device-transfer>
 </data-extraction-rules>

--- a/version.properties
+++ b/version.properties
@@ -1,10 +1,10 @@
 #Automated Version Update
-#Sat Apr 04 17:46:45 CDT 2026
-BUILD=382
+#Tue Apr 14 16:12:31 UTC 2026
+BUILD=383
 LAST_MAJOR=1
 LAST_MINOR=5
 MAJOR=1
 MINOR=5
-PATCH=29
-versionCode=382
-versionName=1.5.29.382
+PATCH=30
+versionCode=383
+versionName=1.5.30.383


### PR DESCRIPTION
Configures default backup inclusion/exclusion rules in `data_extraction_rules.xml` and `backup_rules.xml` to omit potentially sensitive local data (root, external, and database files) in accordance with the TODO comments, ensuring consistent and secure local data handling during Android backups and device transfers.

---
*PR created automatically by Jules for task [1590444469278390967](https://jules.google.com/task/1590444469278390967) started by @HereLiesAz*

## Summary by Sourcery

Update Android backup and data extraction configuration to exclude sensitive local data from backups and device transfers.

Bug Fixes:
- Activate previously commented-out exclusions for root, database, and external storage domains in data_extraction_rules.xml for both cloud backup and device transfer.
- Enable exclusions for root, database, and external storage domains in backup_rules.xml to align with security guidance.

Build:
- Bump app version and build numbers in version.properties.

CI:
- Disable Gradle dependency graph generation in the Android debug APK release GitHub Actions workflow.