### PR TITLE
Stop force-close on Expert/Beginner mode switch

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
@@ -100,6 +100,9 @@ class MainViewModel @Inject constructor(
                 try {
                     processEvent(event)
                 } catch (t: Throwable) {
+                    // Let cancellation propagate so structured concurrency keeps working
+                    // if processEvent ever becomes suspending.
+                    if (t is kotlinx.coroutines.CancellationException) throw t
                     android.util.Log.e(
                         "MainViewModel",
                         "Reducer crashed processing $event",
@@ -328,6 +331,10 @@ class MainViewModel @Inject constructor(
                     userPreferencesRepository.saveState(derivedState)
                     tableScanRepository.saveFeltSamples(derivedState.savedFeltSamples)
                 } catch (t: Throwable) {
+                    // saveJob is cancelled and replaced on every subsequent state emit,
+                    // so CancellationException is normal here — rethrow to keep
+                    // structured concurrency intact and avoid log spam.
+                    if (t is kotlinx.coroutines.CancellationException) throw t
                     // Persistence failures (gson serialization, datastore IO) must not
                     // crash the app via the global uncaught-exception handler.
                     android.util.Log.e("MainViewModel", "saveState failed", t)

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
@@ -93,9 +93,19 @@ class MainViewModel @Inject constructor(
     init {
         // Single background coroutine that serially processes all events —
         // keeps heavy computation (matrices, geometry) off the main thread.
+        // Per-event try/catch keeps a single bad event from killing the whole
+        // loop (and the app, since uncaught coroutine exceptions force-close).
         viewModelScope.launch(Dispatchers.Default) {
             for (event in eventChannel) {
-                processEvent(event)
+                try {
+                    processEvent(event)
+                } catch (t: Throwable) {
+                    android.util.Log.e(
+                        "MainViewModel",
+                        "Reducer crashed processing $event",
+                        t
+                    )
+                }
             }
         }
 
@@ -307,15 +317,21 @@ class MainViewModel @Inject constructor(
         }
 
         if (type != UpdateType.SPIN_ONLY) {
-            val isHighPriority = type == UpdateType.FULL || 
+            val isHighPriority = type == UpdateType.FULL ||
                                state.tableScanModel != previousState.tableScanModel ||
                                state.viewOffset != previousState.viewOffset
-                               
+
             saveJob?.cancel()
             saveJob = viewModelScope.launch {
-                if (!isHighPriority) delay(2000L)
-                userPreferencesRepository.saveState(derivedState)
-                tableScanRepository.saveFeltSamples(derivedState.savedFeltSamples)
+                try {
+                    if (!isHighPriority) delay(2000L)
+                    userPreferencesRepository.saveState(derivedState)
+                    tableScanRepository.saveFeltSamples(derivedState.savedFeltSamples)
+                } catch (t: Throwable) {
+                    // Persistence failures (gson serialization, datastore IO) must not
+                    // crash the app via the global uncaught-exception handler.
+                    android.util.Log.e("MainViewModel", "saveState failed", t)
+                }
             }
         }
     }

--- a/app/src/main/java/com/hereliesaz/cuedetat/view/ProtractorOverlay.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/view/ProtractorOverlay.kt
@@ -99,8 +99,10 @@ fun ProtractorOverlay(
             // in geometry on the first frame after mode-switch doesn't kill the app.
             try {
                 renderer.draw(canvas.nativeCanvas, uiState, paints, barbaroTypeface, context, topDownProgress)
-            } catch (t: Throwable) {
-                android.util.Log.e("ProtractorOverlay", "renderer.draw failed", t)
+            } catch (e: Exception) {
+                // Catch Exception (not Throwable) so JVM Errors like OutOfMemoryError
+                // still propagate — recovering from those is unsafe.
+                android.util.Log.e("ProtractorOverlay", "renderer.draw failed", e)
             }
         }
     }

--- a/app/src/main/java/com/hereliesaz/cuedetat/view/ProtractorOverlay.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/view/ProtractorOverlay.kt
@@ -94,7 +94,14 @@ fun ProtractorOverlay(
         // Read the trigger to inform Compose's invalidation tracker
         drawTrigger
         drawIntoCanvas { canvas ->
-            renderer.draw(canvas.nativeCanvas, uiState, paints, barbaroTypeface, context, topDownProgress)
+            // Renderer crashes here force-close the app because Compose's drawscope
+            // doesn't isolate frame errors. Catch and log so a transient null/NaN
+            // in geometry on the first frame after mode-switch doesn't kill the app.
+            try {
+                renderer.draw(canvas.nativeCanvas, uiState, paints, barbaroTypeface, context, topDownProgress)
+            } catch (t: Throwable) {
+                android.util.Log.e("ProtractorOverlay", "renderer.draw failed", t)
+            }
         }
     }
 }


### PR DESCRIPTION
## Symptoms
The app force-closes when the user taps **Expert** or **Beginner** on the splash screen. **Hater** mode does not crash. Hater renders `HaterScreen`; the other two render `ProtractorScreen`, which composes `ProtractorOverlay`'s renderer and runs the full state pipeline (`updateMatricesAndTransforms` → `updateAimingCalculations`).

## Why this could not be diagnosed remotely
Without an attached device or logcat capture, the exact stack trace is unknown. The plausible failure sites are guarded but numerous: `UpdateStateUseCase` early-returns when `viewWidth/Height == 0`, leaving matrices null on the first emit; renderers null-check most matrices but compute `Matrix.invert()`, `getValues()`, perspective math that can return NaN/Infinity on degenerate input; a `viewModelScope.launch` without an exception handler will crash the process via the global uncaught handler if `gson.toJson(state)` or DataStore IO throws.

## What this PR does
Two surgical try/catch wrappers convert force-close into a logged exception so the underlying problem can be diagnosed via logcat without killing the user's session:

- `MainViewModel` — wrap each `processEvent(event)` call in the event-loop coroutine, and the `saveJob` coroutine, so a reducer or persistence failure logs to `Log.e` instead of propagating to the uncaught-exception handler.
- `ProtractorOverlay` — wrap `renderer.draw(...)` inside the Compose `drawIntoCanvas` block so a transient null/NaN on the first post-mode-switch frame logs instead of crashing the draw scope.

## What this does not do
This is a safety net, not a root-cause fix. Once a real device produces a logcat trace from one of the new `Log.e` lines, the actual crash site can be patched directly. Behavior on the happy path is unchanged.

## Test plan
- [ ] Install on a device, tap **Expert** — app should reach the protractor overlay (or, if a latent bug remains, log the failure under tag `MainViewModel` / `ProtractorOverlay` rather than force-close)
- [ ] Same for **Beginner**
- [ ] Confirm **Hater** still works
- [ ] Run unit tests: `./gradlew :app:testDebugUnitTest`

https://claude.ai/code/session_017dwQX7GTRyvPscHeWEP4P6

---
_Generated by [Claude Code](https://claude.ai/code/session_017dwQX7GTRyvPscHeWEP4P6)_

## Summary by Sourcery

Add defensive error handling around event processing, state persistence, and protractor rendering to prevent crashes when switching modes.

Bug Fixes:
- Prevent app force-closes by catching and logging exceptions in the main event-processing loop instead of letting them terminate the app.
- Prevent crashes during deferred state save operations by catching persistence-related exceptions and logging them.
- Avoid crashes in the protractor overlay draw pipeline by catching and logging rendering exceptions during canvas drawing.