### PR TITLE
fix: paywall regression, FOSS expert mode, license-test redemption

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/UserPreferencesRepository.kt
@@ -94,7 +94,12 @@ class UserPreferencesRepository @Inject constructor(
 
     suspend fun saveState(state: CueDetatState) {
         dataStore.edit { preferences ->
-            val stateToSave = state.copy(experienceMode = null)
+            // isExpertEntitled is sourced live from EntitlementRepository on every
+            // launch — persisting it lets stale values clobber the FOSS build's
+            // always-true entitlement (and a Play user's just-redeemed purchase)
+            // when the saved state is reloaded after the entitlement event has
+            // already updated _uiState.
+            val stateToSave = state.copy(experienceMode = null, isExpertEntitled = false)
             val jsonString = gson.toJson(stateToSave)
             preferences[PreferencesKeys.STATE_JSON] = jsonString
         }

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
@@ -128,9 +128,15 @@ class MainViewModel @Inject constructor(
             val savedState = userPreferencesRepository.stateFlow.first()
             val savedFeltSamples = tableScanRepository.loadFeltSamples()
             val currentExperienceMode = _uiState.value.experienceMode
+            // Pull the entitlement live rather than from the JSON snapshot. The
+            // entitlement event may already have set _uiState.isExpertEntitled
+            // by the time this load completes; in any case the StateFlow is the
+            // source of truth.
+            val liveEntitled = entitlementRepository.entitlement.value.active
             val initialState = (savedState ?: CueDetatState()).copy(
                 experienceMode = currentExperienceMode,
-                savedFeltSamples = savedFeltSamples
+                savedFeltSamples = savedFeltSamples,
+                isExpertEntitled = liveEntitled
             )
             processAndEmitState(initialState, UpdateType.FULL)
 

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallSheet.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallSheet.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
@@ -82,8 +81,7 @@ fun PaywallSheet(
             Text(
                 "Full AR table tracking, ball selection, glasses mode, and the ability to " +
                         "feel marginally less bad about yourself.",
-                style = MaterialTheme.typography.bodyMedium,
-                textAlign = TextAlign.Center
+                style = MaterialTheme.typography.bodyMedium
             )
             Spacer(Modifier.height(24.dp))
 
@@ -128,8 +126,7 @@ fun PaywallSheet(
             Spacer(Modifier.height(16.dp))
             Text(
                 "Free trial, then the price shown. Cancel anytime in Google Play.",
-                style = MaterialTheme.typography.bodySmall,
-                textAlign = TextAlign.Center
+                style = MaterialTheme.typography.bodySmall
             )
             Spacer(Modifier.height(16.dp))
             TextButton(onClick = { viewModel.restore() }) { Text("Restore Purchases") }
@@ -151,7 +148,6 @@ fun PaywallSheet(
             Text(
                 text = githubFooter,
                 style = MaterialTheme.typography.bodySmall,
-                textAlign = TextAlign.Center,
                 modifier = Modifier.padding(top = 8.dp)
             )
         }
@@ -172,7 +168,7 @@ private fun PlanCard(
             modifier = Modifier.padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(title, style = MaterialTheme.typography.titleMedium, textAlign = TextAlign.Center)
+            Text(title, style = MaterialTheme.typography.titleMedium)
             Spacer(Modifier.height(8.dp))
             Row {
                 Text(formattedPrice, style = MaterialTheme.typography.headlineSmall)

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallViewModel.kt
@@ -40,14 +40,13 @@ class PaywallViewModel @Inject constructor(
         }
         viewModelScope.launch {
             // StateFlow already deduplicates equal values, so no need for distinctUntilChanged.
+            // Every paywall surface in this app is reached because the user
+            // tried to use Expert. After a successful purchase we should drop
+            // them into Expert automatically; making them tap Expert a second
+            // time looks like the redemption silently failed.
             repository.entitlement.collect { entitlement ->
-                if (entitlement.active &&
-                    triggerSnapshot == PaywallTrigger.EXPERT_TOGGLE_TAP
-                ) {
+                if (entitlement.active && triggerSnapshot != null) {
                     _purchaseFlowResults.emit(PurchaseFlowEvent.PurchasedAutoEnterExpert)
-                    triggerSnapshot = null
-                } else if (entitlement.active && triggerSnapshot != null) {
-                    _purchaseFlowResults.emit(PurchaseFlowEvent.PurchasedNoAutoEnter)
                     triggerSnapshot = null
                 }
             }

--- a/version.properties
+++ b/version.properties
@@ -1,10 +1,10 @@
 #Automated Version Update
 #Fri May 08 21:39:02 CDT 2026
-BUILD=510
+BUILD=511
 LAST_MAJOR=1
 LAST_MINOR=8
 MAJOR=1
 MINOR=8
-PATCH=5
-versionCode=510
-versionName=1.8.5.510
+PATCH=6
+versionCode=511
+versionName=1.8.6.511


### PR DESCRIPTION
## Summary

Three related fixes around the new subscription / Expert-mode flow.

**Paywall UI regression** — `525ff69` was supposed to add only the GitHub footer line at the bottom of the paywall sheet. The AI also center-aligned every text element on the way through. Reverted those `textAlign = TextAlign.Center` additions; the GitHub footer line stays.

**FOSS Expert mode won't load** — `MainViewModel.init` loads the saved JSON state and calls `processAndEmitState(...)`, which writes directly to `_uiState.value`. `UserPreferencesRepository.saveState()` was persisting `isExpertEntitled` (it only blanked `experienceMode`), so on every launch the FOSS build's permanent `active = true` entitlement event was clobbered by the persisted `false`, leaving Expert locked. `saveState` no longer persists the flag, and the load path now reads `isExpertEntitled` live from `EntitlementRepository.entitlement.value` instead of from the snapshot.

**License-test purchases not redeeming** — `PaywallViewModel` was only emitting `PurchasedAutoEnterExpert` when the trigger was `EXPERT_TOGGLE_TAP`. Splash, onboarding, and nav-tile paths used different triggers and got `PurchasedNoAutoEnter`, dropping the user back on the splash screen after a successful test purchase — looks like the redemption failed. Every paywall surface in this app is reached because the user tried to use Expert, so any non-null trigger now auto-enters. The same `isExpertEntitled` clobber above also caused the entitlement to disappear on the next process launch, compounding the impression of a broken redemption.

Version bumped to 1.8.6.511.

## Test plan

- [ ] FOSS build: tap Expert from splash → enters Expert mode without paywall and survives an app restart.
- [ ] Play build, license tester: subscribe via the splash/onboarding paywall → user is dropped directly into Expert mode after the Play Store flow returns.
- [ ] Play build, license tester: kill and relaunch app after purchase → still in Expert mode (entitlement re-resolved live, not from saved state).
- [ ] Paywall sheet: copy is left-aligned again; only the new GitHub footer is centered/styled at the bottom.
- [ ] Existing `EntitlementReducerTest` and `ToggleReducerEntitlementTest` still pass.

https://claude.ai/code/session_01PwzfR6kExbLPfyci8N9Yfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwzfR6kExbLPfyci8N9Yfh)_

## Summary by Sourcery

Fix subscription and expert-mode entitlement handling while correcting a paywall UI regression and bumping the app version.

Bug Fixes:
- Ensure successful purchases always auto-enter Expert mode regardless of paywall entry trigger.
- Restore left-aligned paywall copy while keeping the GitHub footer styling.
- Load Expert entitlement from the live entitlement repository instead of persisted state to keep FOSS and purchased entitlements active.
- Stop persisting Expert entitlement in user preferences to avoid stale values overwriting current entitlements.

Build:
- Increment app version to 1.8.6.511.