### PR TITLE
Claude/fix subscription expert mode 4f gp5

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/data/VisionData.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/VisionData.kt
@@ -8,7 +8,7 @@ import android.graphics.Rect
 import org.opencv.core.Mat
 
 enum class BallType {
-    UNKNOWN, SOLID, STRIPE
+    UNKNOWN, SOLID, STRIPE, CUE, EIGHT
 }
 
 @Keep

--- a/app/src/main/java/com/hereliesaz/cuedetat/data/VisionRepository.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/VisionRepository.kt
@@ -953,20 +953,41 @@ class VisionRepository @Inject constructor(
         val roi = OCVRect(x, y, w, h)
         val ballMat = frame.submat(roi)
 
-        val poleHeight = (h * 0.15f).toInt().coerceAtLeast(1)
-        val topPole = ballMat.submat(OCVRect(0, 0, w, poleHeight))
-        val bottomPole = ballMat.submat(OCVRect(0, h - poleHeight, w, poleHeight))
-
         val hsvMat = Mat()
         Imgproc.cvtColor(ballMat, hsvMat, Imgproc.COLOR_BGR2HSV)
+
+        // Sample the ball's middle band (avoids glare/shadow at the poles) for
+        // the whole-ball mean used to spot the cue and the 8 ball. A pure-white
+        // cue ball reads as low saturation + high value across the entire ball;
+        // a pure-black 8 ball reads as low value across the entire ball. Stripes
+        // and solids both have a coloured band in the middle so they fall through.
+        val midTop = (h * 0.30f).toInt().coerceIn(0, h - 1)
+        val midH = (h * 0.40f).toInt().coerceAtLeast(1).coerceAtMost(h - midTop)
+        val midHsv = hsvMat.submat(OCVRect(0, midTop, w, midH))
+        val midMean = Core.mean(midHsv)
+        midHsv.release()
+
+        val isWhole8Ball = midMean.`val`[2] < 60.0
+        val isWholeCueBall = midMean.`val`[1] < 40.0 && midMean.`val`[2] > 190.0
+
+        if (isWhole8Ball) {
+            ballMat.release()
+            hsvMat.release()
+            return BallType.EIGHT
+        }
+        if (isWholeCueBall) {
+            ballMat.release()
+            hsvMat.release()
+            return BallType.CUE
+        }
+
+        val poleHeight = (h * 0.15f).toInt().coerceAtLeast(1)
         val topHsv = hsvMat.submat(OCVRect(0, 0, w, poleHeight))
         val bottomHsv = hsvMat.submat(OCVRect(0, h - poleHeight, w, poleHeight))
 
         val topMean = Core.mean(topHsv)
         val bottomMean = Core.mean(bottomHsv)
 
-        topPole.release()
-        bottomPole.release()
         topHsv.release()
         bottomHsv.release()
         ballMat.release()

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/AzNavRailMenu.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/AzNavRailMenu.kt
@@ -107,7 +107,6 @@ fun AzNavRailMenu(
         if (inArSubMode) {
             azRailToggle(
                 id = "target_type",
-                route = "target_type",
                 isChecked = uiState.targetType == com.hereliesaz.cuedetat.domain.TargetType.STRIPES,
                 toggleOnText = "Stripes", toggleOffText = "Solids",
                 fillColor = if (uiState.targetType == com.hereliesaz.cuedetat.domain.TargetType.STRIPES) b4P else b8K,

--- a/app/src/main/java/com/hereliesaz/cuedetat/view/renderer/ball/BallRenderer.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/view/renderer/ball/BallRenderer.kt
@@ -473,13 +473,21 @@ class BallRenderer {
 
     private fun drawBoundingBoxes(canvas: Canvas, state: CueDetatState, paints: PaintCache) {
         val visionData = state.visionData ?: return
-        if (visionData.detectedBoundingBoxes.isEmpty() || visionData.sourceImageWidth == 0) return
+        if (visionData.sourceImageWidth == 0) return
 
-        val paint = Paint(paints.cvResultPaint).apply {
-            style = Paint.Style.STROKE
-            strokeWidth = 3f
-            alpha = 150
+        // Prefer the typed ball list so we can colour by classification. Fall
+        // back to the untyped boundingBoxes when classification hasn't run yet
+        // (e.g. raw OpenCV path with no per-ball type info).
+        val typedBoxes = visionData.balls.mapNotNull { ball ->
+            ball.boundingBox?.let { it to ball.type }
         }
+        val boxes: List<Pair<android.graphics.Rect, com.hereliesaz.cuedetat.data.BallType>> =
+            if (typedBoxes.isNotEmpty()) {
+                typedBoxes
+            } else {
+                visionData.detectedBoundingBoxes.map { it to com.hereliesaz.cuedetat.data.BallType.UNKNOWN }
+            }
+        if (boxes.isEmpty()) return
 
         val rotation = visionData.sourceImageRotation.toFloat()
         val srcWidth = visionData.sourceImageWidth.toFloat()
@@ -493,12 +501,26 @@ class BallRenderer {
         matrix.setRectToRect(srcRect, destRect, Matrix.ScaleToFit.FILL)
         matrix.postRotate(rotation, canvasWidth / 2f, canvasHeight / 2f)
 
+        val paint = Paint(paints.cvResultPaint).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = 3f
+            alpha = 200
+        }
 
-        visionData.detectedBoundingBoxes.forEach { box ->
+        boxes.forEach { (box, type) ->
+            paint.color = colorForBallType(type).toArgb()
             val boxRect = RectF(box)
             matrix.mapRect(boxRect)
             canvas.drawRect(boxRect, paint)
         }
+    }
+
+    private fun colorForBallType(type: com.hereliesaz.cuedetat.data.BallType): Color = when (type) {
+        com.hereliesaz.cuedetat.data.BallType.SOLID -> Color(0xFFFFEB3B)   // yellow
+        com.hereliesaz.cuedetat.data.BallType.STRIPE -> Color(0xFF00E5FF)  // cyan
+        com.hereliesaz.cuedetat.data.BallType.CUE -> Color(0xFFFFFFFF)     // white
+        com.hereliesaz.cuedetat.data.BallType.EIGHT -> Color(0xFFE040FB)   // magenta (8-ball is black; magenta reads against the table)
+        com.hereliesaz.cuedetat.data.BallType.UNKNOWN -> Color(0xFF9E9E9E) // gray
     }
 
     private fun drawAllLabels(

--- a/version.properties
+++ b/version.properties
@@ -1,10 +1,10 @@
 #Automated Version Update
 #Fri May 08 21:39:02 CDT 2026
-BUILD=514
+BUILD=515
 LAST_MAJOR=1
 LAST_MINOR=8
 MAJOR=1
 MINOR=8
-PATCH=9
-versionCode=514
-versionName=1.8.9.514
+PATCH=10
+versionCode=515
+versionName=1.8.10.515

--- a/version.properties
+++ b/version.properties
@@ -1,10 +1,10 @@
 #Automated Version Update
 #Fri May 08 21:39:02 CDT 2026
-BUILD=513
+BUILD=514
 LAST_MAJOR=1
 LAST_MINOR=8
 MAJOR=1
 MINOR=8
-PATCH=8
-versionCode=513
-versionName=1.8.8.513
+PATCH=9
+versionCode=514
+versionName=1.8.9.514


### PR DESCRIPTION
## Summary by Sourcery

Classify and color-code detected pool balls in vision rendering while improving ball type detection and bumping the app version.

New Features:
- Render bounding boxes with colors based on detected ball types, including cue and 8-ball classes.
- Introduce explicit BallType variants for cue and 8-ball to distinguish them from solids and stripes.

Enhancements:
- Improve ball classification by analyzing the ball's middle band in HSV space to better detect cue and 8 balls and avoid glare at the poles.
- Fallback to drawing untyped bounding boxes when per-ball classification is unavailable, ensuring boxes still render.
- Adjust bounding box paint opacity and use a consistent color when type is unknown.
- Simplify AR sub-mode nav rail toggle by removing an unused route parameter.

Build:
- Increment app version and build metadata in version.properties.