### PR TITLE
ui: fix Hater nav crash, auto-show paywall on splash, add support blurb

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/MainActivity.kt
@@ -157,6 +157,18 @@ class MainActivity : ComponentActivity() {
         val showSplashScreen = uiState.experienceMode == null
         var haterModeLockedOrientation by rememberSaveable { mutableStateOf(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED) }
 
+        // Auto-show the subscription popup whenever the splash screen first
+        // appears in this session. Survives configuration changes; re-fires
+        // after process death (splash always shows on cold launch).
+        var hasAutoShownSplashPaywall by rememberSaveable { mutableStateOf(false) }
+        LaunchedEffect(showSplashScreen) {
+            if (showSplashScreen && !hasAutoShownSplashPaywall) {
+                hasAutoShownSplashPaywall = true
+                paywallShowSequence = paywallShowSequence + 1
+                paywallTrigger = com.hereliesaz.cuedetat.billing.PaywallTrigger.SPLASH_SCREEN
+            }
+        }
+
         LaunchedEffect(uiState.experienceMode, uiState.orientationLock) {
             if (uiState.experienceMode == ExperienceMode.HATER) {
                 if (haterModeLockedOrientation == ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED) {

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallSheet.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallSheet.kt
@@ -4,15 +4,19 @@ package com.hereliesaz.cuedetat.ui.composables.paywall
 
 import android.app.Activity
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -31,9 +35,12 @@ import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.hereliesaz.cuedetat.billing.BasePlanId
 import com.hereliesaz.cuedetat.billing.PaywallTrigger
@@ -63,6 +70,67 @@ fun PaywallSheet(
                 }
                 is PaywallViewModel.PurchaseFlowEvent.PurchasedNoAutoEnter -> {
                     onDismiss()
+                }
+            }
+        }
+    }
+
+    // Top-half note rendered above the modal sheet's scrim. Composed BEFORE
+    // ModalBottomSheet so the sheet's window stacks above and remains
+    // interactive; the popup is non-focusable so it never steals input.
+    Popup(
+        alignment = Alignment.TopCenter,
+        properties = PopupProperties(focusable = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(0.5f)
+                    .padding(top = 24.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f)
+                )
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(20.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    val supportBlurb = buildAnnotatedString {
+                        append(
+                            "For the price of one game of pool per month, you make sure " +
+                                "this app stays updated and all bugs are addressed quickly. " +
+                                "It's just little ol' me over here. "
+                        )
+                        append("Cue D'etat is always available in its entirety for free on ")
+                        withLink(
+                            LinkAnnotation.Url(
+                                url = "https://github.com/HereLiesAz/CueDetat",
+                                styles = TextLinkStyles(
+                                    style = SpanStyle(
+                                        color = MaterialTheme.colorScheme.primary,
+                                        textDecoration = TextDecoration.Underline
+                                    )
+                                )
+                            )
+                        ) {
+                            append("Github")
+                        }
+                        append(".")
+                    }
+                    Text(
+                        text = supportBlurb,
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center
+                    )
                 }
             }
         }
@@ -131,25 +199,6 @@ fun PaywallSheet(
             Spacer(Modifier.height(16.dp))
             TextButton(onClick = { viewModel.restore() }) { Text("Restore Purchases") }
             TextButton(onClick = onDismiss) { Text("Continue in Beginner Mode") }
-
-            Spacer(Modifier.height(16.dp))
-            val githubFooter = buildAnnotatedString {
-                append("Cue D'etat is always available in its entirety for free on ")
-                withLink(
-                    LinkAnnotation.Url(
-                        url = "https://github.com/HereLiesAz/CueDetat",
-                        styles = TextLinkStyles(style = SpanStyle(color = MaterialTheme.colorScheme.primary, textDecoration = TextDecoration.Underline))
-                    )
-                ) {
-                    append("Github")
-                }
-                append(".")
-            }
-            Text(
-                text = githubFooter,
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(top = 8.dp)
-            )
         }
     }
 }

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/hatemode/HaterScreen.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/hatemode/HaterScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.hereliesaz.cuedetat.domain.CueDetatState
@@ -68,6 +70,15 @@ fun HaterScreen(
         navController = navController,
         currentDestination = currentRoute
     ) {
+        // Rail items default to route="main"; without a registered destination,
+        // AzNavRail's internal navController.navigate("main") throws
+        // IllegalArgumentException on every rail tap (shake, exit, etc).
+        background(weight = 2) {
+            NavHost(navController = navController, startDestination = "main") {
+                composable("main") { /* HUD lives in background/onscreen layers */ }
+            }
+        }
+
         // --- Background layer: physics / die canvas ---
         background(weight = 0) {
             val answerText = HaterResponses.allAnswers.getOrElse(state.answerIndex) { "" }


### PR DESCRIPTION
## Summary

- **Hater Mode crash**: `HaterScreen` was creating a fresh `NavController` via `rememberNavController()` but never registering a `NavHost`. AzNavRail's internal click handler does `navController.navigate(item.route)` for any rail item with a non-null route, and `azRailItemLowerCase` defaults `route = "main"`. Tapping any rail tile in Hater Mode (the user reported it as "spin", but `shake`/`exit` would have crashed identically) threw `IllegalArgumentException: Navigation destination that matches request ... cannot be found in the navigation graph`. Fixed by registering a `NavHost` with a `"main"` destination in HaterScreen, mirroring ProtractorScreen.
- **Splash → paywall**: `MainActivity.AppContent` now auto-triggers `PaywallTrigger.SPLASH_SCREEN` the first time the splash appears in a session (gated by a `rememberSaveable` flag so config changes don't re-fire it).
- **Paywall support blurb**: `PaywallSheet` now renders a top-half `Popup` containing the "for the price of one game of pool per month..." support note, with the GitHub-availability link appended to the end of that blurb. The duplicate GitHub footer inside the bottom sheet was removed.

## Test plan

- [ ] Cold-launch the app — splash appears AND the subscription bottom sheet auto-presents with the support blurb in the top half.
- [ ] Pick Hater mode from the splash; tap each rail tile (`shake`, `exit`) — no crash. (`spin` is correctly hidden in Hater mode.)
- [ ] Open the paywall via the "Get Expert" rail tile in Beginner mode — same support blurb appears at top, GitHub link is clickable, no duplicate GitHub footer at the bottom of the sheet.
- [ ] Rotate the device while on the splash — paywall does not re-fire.

https://claude.ai/code/session_01J2EKpynkb9xK8BopXRWv2S

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2EKpynkb9xK8BopXRWv2S)_