### PR TITLE
Fix beginner-mode ball detection + replace 6-pocket scan with 4-corner-tap quad

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/data/CvBallDetector.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/CvBallDetector.kt
@@ -1,0 +1,251 @@
+// app/src/main/java/com/hereliesaz/cuedetat/data/CvBallDetector.kt
+package com.hereliesaz.cuedetat.data
+
+import android.graphics.PointF
+import android.graphics.Rect
+import org.opencv.core.Core
+import org.opencv.core.CvType
+import org.opencv.core.Mat
+import org.opencv.core.Scalar
+import org.opencv.core.Size
+import org.opencv.imgproc.Imgproc
+import kotlin.math.PI
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.sqrt
+import org.opencv.core.Rect as CvRect
+
+/**
+ * Classical-CV ball detector that runs alongside the ML model. Uses the felt
+ * mask as a prior: balls are circular non-felt regions surrounded by felt.
+ *
+ * Pipeline:
+ *  1. Build felt mask from sampled HSV (mean ± stdDev tolerance).
+ *  2. Morphologically close to seal ball-sized holes in the felt.
+ *  3. Subtract the original mask: the resulting blobs are ball candidates.
+ *  4. Filter blobs by area and circularity.
+ *  5. For each blob, run Hough circles in a local crop to refine sub-pixel
+ *     centre and radius.
+ *  6. Classify cue / 8 / solid / stripe from interior colour.
+ */
+class CvBallDetector {
+
+    data class Detection(
+        val center: PointF,
+        val radius: Float,
+        val type: BallType,
+        val confidence: Float,
+    )
+
+    private val feltMask = Mat()
+    private val closedMask = Mat()
+    private val ballMask = Mat()
+    private val labels = Mat()
+    private val stats = Mat()
+    private val centroids = Mat()
+    private val gray = Mat()
+    private val circlesMat = Mat()
+    private val hierarchy = Mat()
+    private var morphKernel: Mat? = null
+
+    /**
+     * @param bgrMat full-resolution BGR frame
+     * @param hsvMat full-resolution HSV frame (same dimensions)
+     * @param feltHsv mean felt HSV in OpenCV space (H 0-180, S 0-255, V 0-255)
+     * @param feltStdDev per-channel std dev for inRange tolerance
+     * @param expectedBallRadiusPx hint at expected ball radius in image pixels
+     *        used as the centre of the accepted size range
+     */
+    fun detect(
+        bgrMat: Mat,
+        hsvMat: Mat,
+        feltHsv: FloatArray,
+        feltStdDev: FloatArray,
+        expectedBallRadiusPx: Float = 0f,
+    ): List<Detection> {
+        if (bgrMat.empty() || hsvMat.empty()) return emptyList()
+        if (bgrMat.rows() != hsvMat.rows() || bgrMat.cols() != hsvMat.cols()) return emptyList()
+
+        val sdScale = 2.5f
+        val lower = Scalar(
+            max(0.0, feltHsv[0] - sdScale * feltStdDev[0] - 5.0),
+            max(40.0, feltHsv[1] - sdScale * feltStdDev[1]),
+            max(40.0, feltHsv[2] - sdScale * feltStdDev[2]),
+        )
+        val upper = Scalar(
+            min(180.0, feltHsv[0] + sdScale * feltStdDev[0] + 5.0),
+            min(255.0, feltHsv[1] + sdScale * feltStdDev[1]),
+            min(255.0, feltHsv[2] + sdScale * feltStdDev[2]),
+        )
+
+        Core.inRange(hsvMat, lower, upper, feltMask)
+
+        val frameSide = min(bgrMat.cols(), bgrMat.rows())
+        val estRadius = if (expectedBallRadiusPx > 0f) {
+            expectedBallRadiusPx
+        } else {
+            frameSide * 0.025f
+        }.coerceIn(MIN_RADIUS_PX, MAX_RADIUS_PX)
+
+        val kernelSize = max(3.0, estRadius * 0.8).toInt().let { if (it % 2 == 0) it + 1 else it }
+        morphKernel?.release()
+        val kernel = Imgproc.getStructuringElement(
+            Imgproc.MORPH_ELLIPSE, Size(kernelSize.toDouble(), kernelSize.toDouble())
+        ).also { morphKernel = it }
+
+        Imgproc.morphologyEx(feltMask, closedMask, Imgproc.MORPH_CLOSE, kernel)
+        Core.subtract(closedMask, feltMask, ballMask)
+
+        val componentCount = Imgproc.connectedComponentsWithStats(
+            ballMask, labels, stats, centroids, 8, CvType.CV_32S
+        )
+        if (componentCount <= 1) return emptyList()
+
+        val minArea = (PI * (estRadius * 0.4) * (estRadius * 0.4)).toInt().coerceAtLeast(MIN_AREA_PX)
+        val maxArea = (PI * (estRadius * 2.5) * (estRadius * 2.5)).toInt()
+
+        val results = ArrayList<Detection>()
+
+        for (label in 1 until componentCount) {
+            val area = stats.get(label, Imgproc.CC_STAT_AREA)[0].toInt()
+            if (area < minArea || area > maxArea) continue
+
+            val x = stats.get(label, Imgproc.CC_STAT_LEFT)[0].toInt()
+            val y = stats.get(label, Imgproc.CC_STAT_TOP)[0].toInt()
+            val w = stats.get(label, Imgproc.CC_STAT_WIDTH)[0].toInt()
+            val h = stats.get(label, Imgproc.CC_STAT_HEIGHT)[0].toInt()
+
+            val aspect = max(w, h).toFloat() / min(w, h).toFloat()
+            if (aspect > 2.0f) continue
+
+            val approxRadius = (sqrt(area / PI)).toFloat()
+            val bboxRadius = (max(w, h) / 2f)
+            val circularity = approxRadius / bboxRadius
+            if (circularity < 0.55f) continue
+
+            val pad = (bboxRadius * 0.6f).toInt().coerceAtLeast(4)
+            val cropX = (x - pad).coerceAtLeast(0)
+            val cropY = (y - pad).coerceAtLeast(0)
+            val cropW = (w + 2 * pad).coerceAtMost(bgrMat.cols() - cropX)
+            val cropH = (h + 2 * pad).coerceAtMost(bgrMat.rows() - cropY)
+            if (cropW <= 0 || cropH <= 0) continue
+
+            val crop = bgrMat.submat(CvRect(cropX, cropY, cropW, cropH))
+            try {
+                val refined = refineWithHough(crop, bboxRadius)
+                val (cxLocal, cyLocal, refinedRadius) = refined ?: Triple(
+                    centroids.get(label, 0)[0].toFloat() - cropX,
+                    centroids.get(label, 1)[0].toFloat() - cropY,
+                    bboxRadius,
+                )
+
+                val cx = cxLocal + cropX
+                val cy = cyLocal + cropY
+
+                val type = classifyBallType(
+                    bgrMat,
+                    Rect(
+                        (cx - refinedRadius).toInt().coerceAtLeast(0),
+                        (cy - refinedRadius).toInt().coerceAtLeast(0),
+                        (cx + refinedRadius).toInt().coerceAtMost(bgrMat.cols()),
+                        (cy + refinedRadius).toInt().coerceAtMost(bgrMat.rows()),
+                    )
+                )
+
+                results.add(
+                    Detection(
+                        center = PointF(cx, cy),
+                        radius = refinedRadius,
+                        type = type,
+                        confidence = circularity,
+                    )
+                )
+            } finally {
+                crop.release()
+            }
+        }
+
+        return results
+    }
+
+    private fun refineWithHough(crop: Mat, bboxRadius: Float): Triple<Float, Float, Float>? {
+        Imgproc.cvtColor(crop, gray, Imgproc.COLOR_BGR2GRAY)
+        Imgproc.medianBlur(gray, gray, 3)
+
+        val minR = (bboxRadius * 0.5f).toInt().coerceAtLeast(MIN_RADIUS_PX.toInt())
+        val maxR = (bboxRadius * 1.5f).toInt().coerceAtMost(MAX_RADIUS_PX.toInt())
+        if (minR >= maxR) return null
+
+        Imgproc.HoughCircles(
+            gray, circlesMat, Imgproc.HOUGH_GRADIENT,
+            1.0,
+            (bboxRadius * 1.5).toDouble().coerceAtLeast(8.0),
+            80.0, 18.0,
+            minR, maxR
+        )
+
+        if (circlesMat.empty() || circlesMat.cols() == 0) return null
+
+        val data = DoubleArray(3)
+        circlesMat.get(0, 0, data)
+        return Triple(data[0].toFloat(), data[1].toFloat(), data[2].toFloat())
+    }
+
+    private fun classifyBallType(frame: Mat, box: Rect): BallType {
+        val x = box.left.coerceIn(0, frame.cols() - 1)
+        val y = box.top.coerceIn(0, frame.rows() - 1)
+        val w = (box.right - x).coerceIn(1, frame.cols() - x)
+        val h = (box.bottom - y).coerceIn(1, frame.rows() - y)
+
+        val roi = CvRect(x, y, w, h)
+        val ballMat = frame.submat(roi)
+        val hsv = Mat()
+        try {
+            Imgproc.cvtColor(ballMat, hsv, Imgproc.COLOR_BGR2HSV)
+
+            val midTop = (h * 0.30f).toInt().coerceIn(0, h - 1)
+            val midH = (h * 0.40f).toInt().coerceAtLeast(1).coerceAtMost(h - midTop)
+            val midHsv = hsv.submat(CvRect(0, midTop, w, midH))
+            val midMean = Core.mean(midHsv)
+            midHsv.release()
+
+            if (midMean.`val`[2] < 60.0) return BallType.EIGHT
+            if (midMean.`val`[1] < 40.0 && midMean.`val`[2] > 190.0) return BallType.CUE
+
+            val poleH = (h * 0.15f).toInt().coerceAtLeast(1)
+            val topHsv = hsv.submat(CvRect(0, 0, w, poleH))
+            val bottomHsv = hsv.submat(CvRect(0, h - poleH, w, poleH))
+            val topMean = Core.mean(topHsv)
+            val bottomMean = Core.mean(bottomHsv)
+            topHsv.release()
+            bottomHsv.release()
+
+            val topWhite = topMean.`val`[1] < 50.0 && topMean.`val`[2] > 180.0
+            val bottomWhite = bottomMean.`val`[1] < 50.0 && bottomMean.`val`[2] > 180.0
+            return if (topWhite && bottomWhite) BallType.STRIPE else BallType.SOLID
+        } finally {
+            ballMat.release()
+            hsv.release()
+        }
+    }
+
+    fun release() {
+        feltMask.release()
+        closedMask.release()
+        ballMask.release()
+        labels.release()
+        stats.release()
+        centroids.release()
+        gray.release()
+        circlesMat.release()
+        hierarchy.release()
+        morphKernel?.release()
+        morphKernel = null
+    }
+
+    private companion object {
+        const val MIN_RADIUS_PX = 4f
+        const val MAX_RADIUS_PX = 80f
+        const val MIN_AREA_PX = 50
+    }
+}

--- a/app/src/main/java/com/hereliesaz/cuedetat/data/FeltColorDetector.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/FeltColorDetector.kt
@@ -1,0 +1,123 @@
+// app/src/main/java/com/hereliesaz/cuedetat/data/FeltColorDetector.kt
+package com.hereliesaz.cuedetat.data
+
+import org.opencv.core.Core
+import org.opencv.core.CvType
+import org.opencv.core.Mat
+import org.opencv.core.MatOfDouble
+import org.opencv.core.Scalar
+import org.opencv.imgproc.Imgproc
+
+/**
+ * Auto-detects the felt color of a pool table by finding the largest chromatic
+ * connected component in the frame. No user interaction required, no table pose
+ * dependency.
+ *
+ * Strategy: pool felt is by far the largest saturated surface in any pool-table
+ * scene. Mask out greys, blacks, and blown highlights, then take the largest
+ * remaining connected component. Its mean HSV is the felt color.
+ *
+ * Inputs are expected in OpenCV HSV space: H ∈ [0, 180], S ∈ [0, 255], V ∈ [0, 255].
+ */
+class FeltColorDetector {
+
+    data class Result(
+        val hsv: FloatArray,
+        val stdDev: FloatArray,
+        val coverage: Float,
+        val confidence: Float,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Result) return false
+            return hsv.contentEquals(other.hsv) &&
+                stdDev.contentEquals(other.stdDev) &&
+                coverage == other.coverage &&
+                confidence == other.confidence
+        }
+
+        override fun hashCode(): Int {
+            var result = hsv.contentHashCode()
+            result = 31 * result + stdDev.contentHashCode()
+            result = 31 * result + coverage.hashCode()
+            result = 31 * result + confidence.hashCode()
+            return result
+        }
+    }
+
+    private val chromaticMask = Mat()
+    private val labels = Mat()
+    private val stats = Mat()
+    private val centroids = Mat()
+    private val componentMask = Mat()
+    private val mean = MatOfDouble()
+    private val stdDev = MatOfDouble()
+
+    fun detect(hsvMat: Mat): Result? {
+        if (hsvMat.empty()) return null
+
+        val totalPixels = hsvMat.rows() * hsvMat.cols()
+        if (totalPixels == 0) return null
+
+        Core.inRange(hsvMat, LOWER_CHROMATIC, UPPER_CHROMATIC, chromaticMask)
+
+        val count = Imgproc.connectedComponentsWithStats(
+            chromaticMask, labels, stats, centroids, 8, CvType.CV_32S
+        )
+        if (count <= 1) return null
+
+        var bestLabel = -1
+        var bestArea = 0
+        for (label in 1 until count) {
+            val area = stats.get(label, Imgproc.CC_STAT_AREA)[0].toInt()
+            if (area > bestArea) {
+                bestArea = area
+                bestLabel = label
+            }
+        }
+        if (bestLabel < 0) return null
+
+        val coverage = bestArea.toFloat() / totalPixels.toFloat()
+        if (coverage < MIN_COVERAGE) return null
+
+        Core.compare(labels, Scalar(bestLabel.toDouble()), componentMask, Core.CMP_EQ)
+        Core.meanStdDev(hsvMat, mean, stdDev, componentMask)
+
+        val hsv = floatArrayOf(
+            mean.get(0, 0)[0].toFloat(),
+            mean.get(1, 0)[0].toFloat(),
+            mean.get(2, 0)[0].toFloat(),
+        )
+        val sd = floatArrayOf(
+            stdDev.get(0, 0)[0].toFloat(),
+            stdDev.get(1, 0)[0].toFloat(),
+            stdDev.get(2, 0)[0].toFloat(),
+        )
+
+        val saturationScore = (hsv[1] / 255f).coerceIn(0f, 1f)
+        val coverageScore = ((coverage - MIN_COVERAGE) / (0.5f - MIN_COVERAGE)).coerceIn(0f, 1f)
+        val confidence = (saturationScore * 0.6f + coverageScore * 0.4f).coerceIn(0f, 1f)
+
+        return Result(hsv = hsv, stdDev = sd, coverage = coverage, confidence = confidence)
+    }
+
+    fun release() {
+        chromaticMask.release()
+        labels.release()
+        stats.release()
+        centroids.release()
+        componentMask.release()
+        mean.release()
+        stdDev.release()
+    }
+
+    private companion object {
+        // Reject greys/whites (S < 76 ≈ 30%), shadows (V < 51 ≈ 20%),
+        // and blown highlights (V > 242 ≈ 95%).
+        val LOWER_CHROMATIC: Scalar = Scalar(0.0, 76.0, 51.0)
+        val UPPER_CHROMATIC: Scalar = Scalar(180.0, 255.0, 242.0)
+
+        // Felt must cover at least 8% of the frame to be considered a real candidate.
+        const val MIN_COVERAGE = 0.08f
+    }
+}

--- a/app/src/main/java/com/hereliesaz/cuedetat/data/VisionRepository.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/VisionRepository.kt
@@ -386,9 +386,19 @@ class VisionRepository @Inject constructor(
                 DetectedBall(position = logical, type = d.type, confidence = d.confidence, boundingBox = box)
             }
 
-            val mergeDistanceSq = run {
-                val r = cvDetections.maxOfOrNull { it.radius } ?: 30f
-                (r * 1.5f).let { it * it }
+            // mlBalls.position and cvScreenBalls.position live in the same coord
+            // system as each other (logical inches if hasInverseMatrix, screen pixels
+            // otherwise). The merge threshold must live in that same system, not in
+            // image-pixel units like CvBallDetector.radius. Pick the threshold to match.
+            val mergeDistanceSq = if (state.hasInverseMatrix) {
+                val r = LOGICAL_BALL_RADIUS * 1.5f
+                r * r
+            } else {
+                imageToScreenMatrix.getValues(reusableMatrixValues)
+                val imgToScreen = reusableMatrixValues[Matrix.MSCALE_X]
+                val rImage = cvDetections.maxOfOrNull { it.radius } ?: 30f
+                val rScreen = rImage * imgToScreen * 1.5f
+                rScreen * rScreen
             }
             val cvFillIns = cvScreenBalls.filter { cvBall ->
                 mlBalls.none { mlBall ->
@@ -399,7 +409,11 @@ class VisionRepository @Inject constructor(
             }
 
             val allStructuredBalls = mlBalls + cvFillIns
-            val cvFillInPoints = cvFillIns.map { it.position }
+            // genericBalls must use the same coord system as `balls`. Previously this
+            // path emitted screen-pixel points, which mismatched consumer reducers
+            // (ObstacleReducer, GestureReducer, SnapReducer) that compare against
+            // event.logicalPoint. Use the structured positions, which are logical
+            // when a pose exists and screen otherwise — consistent both ways.
             val genericBalls = allStructuredBalls.map { it.position }
 
             var finalVisionData = VisionData(
@@ -680,9 +694,19 @@ class VisionRepository @Inject constructor(
                 com.hereliesaz.cuedetat.data.DetectedBall(position = logical, type = d.type, confidence = d.confidence, boundingBox = box)
             }
 
-            val mergeDistSq = run {
-                val r = cvDetections.maxOfOrNull { it.radius } ?: 30f
-                (r * 1.5f).let { it * it }
+            // See processImage for the unit-mismatch context: ball positions live in
+            // logical inches when a pose exists, screen pixels otherwise. The AR path
+            // always has a pose, so use logical units, with a screen-pixel fallback
+            // for the degenerate case.
+            val mergeDistSq = if (state.hasInverseMatrix) {
+                val r = LOGICAL_BALL_RADIUS * 1.5f
+                r * r
+            } else {
+                imageToScreenMatrix.getValues(reusableMatrixValues)
+                val imgToScreen = reusableMatrixValues[Matrix.MSCALE_X]
+                val rImage = cvDetections.maxOfOrNull { it.radius } ?: 30f
+                val rScreen = rImage * imgToScreen * 1.5f
+                rScreen * rScreen
             }
             val cvFillIns = cvScreenBalls.filter { cvBall ->
                 mlBalls.none { mlBall ->

--- a/app/src/main/java/com/hereliesaz/cuedetat/data/VisionRepository.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/VisionRepository.kt
@@ -400,7 +400,7 @@ class VisionRepository @Inject constructor(
 
             val allStructuredBalls = mlBalls + cvFillIns
             val cvFillInPoints = cvFillIns.map { it.position }
-            val genericBalls = refinedScreenPoints + cvFillInPoints
+            val genericBalls = allStructuredBalls.map { it.position }
 
             var finalVisionData = VisionData(
                 genericBalls = genericBalls,

--- a/app/src/main/java/com/hereliesaz/cuedetat/data/VisionRepository.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/VisionRepository.kt
@@ -85,6 +85,10 @@ class VisionRepository @Inject constructor(
         Imgproc.getStructuringElement(Imgproc.MORPH_ELLIPSE, Size(5.0, 5.0))
     }
 
+    private val feltColorDetector = FeltColorDetector()
+    private val cvBallDetector = CvBallDetector()
+    private var lastFeltDetection: FeltColorDetector.Result? = null
+
     private val isProcessing = AtomicBoolean(false)
     private var relocaliserFailFrames = 0
 
@@ -170,7 +174,11 @@ class VisionRepository @Inject constructor(
                 Pair(meanArray, stddevArray)
             }
 
-            val hsv = state.lockedHsvColor ?: hsvTuple?.first ?: run {
+            val autoFelt = if (state.lockedHsvColor == null && hsvTuple == null) {
+                feltColorDetector.detect(hsvMat)?.also { lastFeltDetection = it }
+            } else null
+
+            val hsv = state.lockedHsvColor ?: hsvTuple?.first ?: autoFelt?.hsv ?: run {
                 val roiWidth = 50
                 val roiHeight = 50
                 val roiX = (hsvMat.cols() - roiWidth) / 2
@@ -224,17 +232,25 @@ class VisionRepository @Inject constructor(
                 null
             }
 
+            val hasTablePose = state.hasInverseMatrix && state.pitchMatrix != null
             val filteredDetectedObjects = detectedObjects.filter {
                 val box = it.boundingBox
-                val expectedRadius = getExpectedRadiusAtImageY(
-                    box.centerY().toFloat(), state, imageToScreenMatrix
-                )
-                val maxAllowedArea = 2 * Math.PI * expectedRadius.pow(2)
-                (box.width() * box.height()) <= maxAllowedArea
+                if (!hasTablePose) {
+                    val side = minOf(box.width(), box.height())
+                    side in 10..400
+                } else {
+                    val expectedRadius = getExpectedRadiusAtImageY(
+                        box.centerY().toFloat(), state, imageToScreenMatrix
+                    )
+                    val maxAllowedArea = 2 * Math.PI * expectedRadius.pow(2)
+                    (box.width() * box.height()) <= maxAllowedArea
+                }
             }
 
-            val refinedScreenPoints = filteredDetectedObjects.mapNotNull { detectedObject ->
-                refineBallCenter(detectedObject, matToUse, state, imageToScreenMatrix)
+            val refinedScreenPoints = filteredDetectedObjects.map { detectedObject ->
+                val box = detectedObject.boundingBox
+                val fallback = PointF(box.exactCenterX(), box.exactCenterY())
+                refineBallCenter(detectedObject, matToUse, state, imageToScreenMatrix) ?: fallback
             }.map { pointInImageCoords ->
                 val screenPointArray = floatArrayOf(pointInImageCoords.x, pointInImageCoords.y)
                 imageToScreenMatrix.mapPoints(screenPointArray)
@@ -243,15 +259,22 @@ class VisionRepository @Inject constructor(
 
             val filteredCustomPoolBalls = customPoolBalls.filter {
                 val box = it.rect
-                val expectedRadius = getExpectedRadiusAtImageY(
-                    box.centerY(), state, imageToScreenMatrix
-                )
-                val maxAllowedArea = 2 * Math.PI * expectedRadius.pow(2)
-                (box.width() * box.height()) <= maxAllowedArea
+                if (!hasTablePose) {
+                    val side = minOf(box.width(), box.height())
+                    side in 10f..400f
+                } else {
+                    val expectedRadius = getExpectedRadiusAtImageY(
+                        box.centerY(), state, imageToScreenMatrix
+                    )
+                    val maxAllowedArea = 2 * Math.PI * expectedRadius.pow(2)
+                    (box.width() * box.height()) <= maxAllowedArea
+                }
             }
 
-            val customScreenPoints = filteredCustomPoolBalls.mapNotNull { detectedObject ->
-                refineBallCenterPoolDetection(detectedObject, matToUse, state, imageToScreenMatrix)
+            val customScreenPoints = filteredCustomPoolBalls.map { detectedObject ->
+                val box = detectedObject.rect
+                val fallback = PointF(box.centerX(), box.centerY())
+                refineBallCenterPoolDetection(detectedObject, matToUse, state, imageToScreenMatrix) ?: fallback
             }.map { pointInImageCoords ->
                 val screenPointArray = floatArrayOf(pointInImageCoords.x, pointInImageCoords.y)
                 imageToScreenMatrix.mapPoints(screenPointArray)
@@ -322,10 +345,65 @@ class VisionRepository @Inject constructor(
                 DetectedBall(position = logical, type = ballType, confidence = 0.9f, boundingBox = intBox)
             }
 
-            val allStructuredBalls = genericBallsStructured + customBallsStructured
+            val mlBalls = genericBallsStructured + customBallsStructured
+
+            val feltMean = state.lockedHsvColor
+                ?: autoFelt?.hsv
+                ?: lastFeltDetection?.hsv
+            val feltSd = state.lockedHsvStdDev
+                ?: autoFelt?.stdDev
+                ?: lastFeltDetection?.stdDev
+                ?: floatArrayOf(8f, 40f, 50f)
+
+            val cvDetections = if (feltMean != null) {
+                val mlBoxSides = (filteredDetectedObjects.map {
+                    minOf(it.boundingBox.width(), it.boundingBox.height())
+                } + filteredCustomPoolBalls.map {
+                    minOf(it.rect.width(), it.rect.height()).toInt()
+                }).filter { it > 0 }
+                val medianSide = if (mlBoxSides.isNotEmpty()) {
+                    mlBoxSides.sorted()[mlBoxSides.size / 2].toFloat()
+                } else 0f
+                val expectedRadiusPx = medianSide / 2f
+                cvBallDetector.detect(matToUse, hsvMat, feltMean, feltSd, expectedRadiusPx)
+            } else emptyList()
+
+            val cvScreenBalls = cvDetections.map { d ->
+                val arr = floatArrayOf(d.center.x, d.center.y)
+                imageToScreenMatrix.mapPoints(arr)
+                val sp = PointF(arr[0], arr[1])
+                val logical = if (state.hasInverseMatrix) {
+                    val inv = state.inversePitchMatrix ?: Matrix()
+                    val lp = Perspective.screenToLogical(sp, inv)
+                    if (state.lensWarpTps != null) ThinPlateSpline.applyWarp(state.lensWarpTps, lp) else lp
+                } else sp
+                val box = android.graphics.Rect(
+                    (d.center.x - d.radius).toInt(),
+                    (d.center.y - d.radius).toInt(),
+                    (d.center.x + d.radius).toInt(),
+                    (d.center.y + d.radius).toInt(),
+                )
+                DetectedBall(position = logical, type = d.type, confidence = d.confidence, boundingBox = box)
+            }
+
+            val mergeDistanceSq = run {
+                val r = cvDetections.maxOfOrNull { it.radius } ?: 30f
+                (r * 1.5f).let { it * it }
+            }
+            val cvFillIns = cvScreenBalls.filter { cvBall ->
+                mlBalls.none { mlBall ->
+                    val dx = (mlBall.position.x - cvBall.position.x).toDouble()
+                    val dy = (mlBall.position.y - cvBall.position.y).toDouble()
+                    (dx * dx + dy * dy) < mergeDistanceSq
+                }
+            }
+
+            val allStructuredBalls = mlBalls + cvFillIns
+            val cvFillInPoints = cvFillIns.map { it.position }
+            val genericBalls = refinedScreenPoints + cvFillInPoints
 
             var finalVisionData = VisionData(
-                genericBalls = refinedScreenPoints,
+                genericBalls = genericBalls,
                 balls = allStructuredBalls,
                 detectedHsvColor = hsvTuple?.first ?: hsv,
                 detectedBoundingBoxes = filteredDetectedObjects.map { it.boundingBox },
@@ -517,23 +595,35 @@ class VisionRepository @Inject constructor(
             }
 
             Imgproc.cvtColor(matToUse, reusableHsvMat, Imgproc.COLOR_BGR2HSV)
-            val hsv = state.lockedHsvColor ?: run {
-                val roiX = (reusableHsvMat.cols() - 50) / 2
-                val roiY = (reusableHsvMat.rows() - 50) / 2
-                val center = reusableHsvMat.submat(OCVRect(roiX, roiY, 50, 50))
+            val hsvMat = reusableHsvMat
+            val autoFelt = if (state.lockedHsvColor == null) {
+                feltColorDetector.detect(hsvMat)?.also { lastFeltDetection = it }
+            } else null
+            val hsv = state.lockedHsvColor ?: autoFelt?.hsv ?: run {
+                val roiX = (hsvMat.cols() - 50) / 2
+                val roiY = (hsvMat.rows() - 50) / 2
+                val center = hsvMat.submat(OCVRect(roiX, roiY, 50, 50))
                 val mean = Core.mean(center)
                 center.release()
                 floatArrayOf(mean.`val`[0].toFloat(), mean.`val`[1].toFloat(), mean.`val`[2].toFloat())
             }
 
+            val hasTablePose = state.hasInverseMatrix && state.pitchMatrix != null
             val filteredObjects = detectedObjects.filter {
                 val box = it.boundingBox
-                val er = getExpectedRadiusAtImageY(box.centerY().toFloat(), state, imageToScreenMatrix)
-                (box.width() * box.height()) <= 2 * Math.PI * er * er
+                if (!hasTablePose) {
+                    val side = minOf(box.width(), box.height())
+                    side in 10..400
+                } else {
+                    val er = getExpectedRadiusAtImageY(box.centerY().toFloat(), state, imageToScreenMatrix)
+                    (box.width() * box.height()) <= 2 * Math.PI * er * er
+                }
             }
 
-            val refinedScreenPoints = filteredObjects.mapNotNull { obj ->
-                refineBallCenter(obj, matToUse, state, imageToScreenMatrix)
+            val refinedScreenPoints = filteredObjects.map { obj ->
+                val box = obj.boundingBox
+                val fallback = PointF(box.exactCenterX(), box.exactCenterY())
+                refineBallCenter(obj, matToUse, state, imageToScreenMatrix) ?: fallback
             }.map { pt ->
                 val arr = floatArrayOf(pt.x, pt.y)
                 imageToScreenMatrix.mapPoints(arr)
@@ -549,7 +639,7 @@ class VisionRepository @Inject constructor(
                 }
             } else emptyList()
 
-            val allBalls = refinedScreenPoints.mapIndexed { idx, sp ->
+            val mlBalls = refinedScreenPoints.mapIndexed { idx, sp ->
                 val logical = if (state.hasInverseMatrix) {
                     val inv = state.inversePitchMatrix ?: android.graphics.Matrix()
                     val lp = com.hereliesaz.cuedetat.view.model.Perspective.screenToLogical(sp, inv)
@@ -560,7 +650,55 @@ class VisionRepository @Inject constructor(
                 com.hereliesaz.cuedetat.data.DetectedBall(position = logical, type = ballType, confidence = 0.9f, boundingBox = box)
             }
 
-            val filteredBalls = if (state.table.isVisible) logicalPoints.filter { state.table.isPointInside(it) } else logicalPoints
+            val feltMean = state.lockedHsvColor ?: autoFelt?.hsv ?: lastFeltDetection?.hsv
+            val feltSd = state.lockedHsvStdDev
+                ?: autoFelt?.stdDev
+                ?: lastFeltDetection?.stdDev
+                ?: floatArrayOf(8f, 40f, 50f)
+            val cvDetections = if (feltMean != null) {
+                val sides = filteredObjects.map { minOf(it.boundingBox.width(), it.boundingBox.height()) }
+                    .filter { it > 0 }
+                val medianSide = if (sides.isNotEmpty()) sides.sorted()[sides.size / 2].toFloat() else 0f
+                cvBallDetector.detect(matToUse, hsvMat, feltMean, feltSd, medianSide / 2f)
+            } else emptyList()
+
+            val cvScreenBalls = cvDetections.map { d ->
+                val arr = floatArrayOf(d.center.x, d.center.y)
+                imageToScreenMatrix.mapPoints(arr)
+                val sp = android.graphics.PointF(arr[0], arr[1])
+                val logical = if (state.hasInverseMatrix) {
+                    val inv = state.inversePitchMatrix ?: android.graphics.Matrix()
+                    val lp = com.hereliesaz.cuedetat.view.model.Perspective.screenToLogical(sp, inv)
+                    if (state.lensWarpTps != null) com.hereliesaz.cuedetat.domain.ThinPlateSpline.applyWarp(state.lensWarpTps, lp) else lp
+                } else sp
+                val box = android.graphics.Rect(
+                    (d.center.x - d.radius).toInt(),
+                    (d.center.y - d.radius).toInt(),
+                    (d.center.x + d.radius).toInt(),
+                    (d.center.y + d.radius).toInt(),
+                )
+                com.hereliesaz.cuedetat.data.DetectedBall(position = logical, type = d.type, confidence = d.confidence, boundingBox = box)
+            }
+
+            val mergeDistSq = run {
+                val r = cvDetections.maxOfOrNull { it.radius } ?: 30f
+                (r * 1.5f).let { it * it }
+            }
+            val cvFillIns = cvScreenBalls.filter { cvBall ->
+                mlBalls.none { mlBall ->
+                    val dx = (mlBall.position.x - cvBall.position.x).toDouble()
+                    val dy = (mlBall.position.y - cvBall.position.y).toDouble()
+                    (dx * dx + dy * dy) < mergeDistSq
+                }
+            }
+
+            val allBalls = mlBalls + cvFillIns
+            val cvFillInPositions = cvFillIns.map { it.position }
+            val filteredBalls = if (state.table.isVisible) {
+                (logicalPoints + cvFillInPositions).filter { state.table.isPointInside(it) }
+            } else {
+                logicalPoints + cvFillInPositions
+            }
 
             _visionDataFlow.value = VisionData(
                 genericBalls = filteredBalls,

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanScreen.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanScreen.kt
@@ -21,14 +21,20 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.clickable
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -56,6 +62,8 @@ import com.hereliesaz.cuedetat.domain.CueDetatState
 import com.hereliesaz.cuedetat.domain.MainScreenEvent
 import com.hereliesaz.cuedetat.domain.PocketId
 import kotlinx.coroutines.delay
+import kotlin.math.roundToInt
+import android.graphics.PointF as AndroidPointF
 
 /**
  * Full-screen scan UI.
@@ -82,6 +90,7 @@ fun TableScanScreen(
     val capturedHsv by viewModel.capturedFeltHsv.collectAsState()
     val scanStep by viewModel.scanStep.collectAsState()
     val currentPocketTarget by viewModel.currentPocketTarget.collectAsState()
+    val cornerTaps by viewModel.cornerTaps.collectAsState()
 
     val capturedCount = PocketId.entries.count { id ->
         currentPocketTarget != null &&
@@ -230,6 +239,7 @@ fun TableScanScreen(
         val showReticle = when (scanStep) {
             ScanStep.FELT_CAPTURE -> capturedHsv == null
             ScanStep.POCKET_GUIDE -> true
+            ScanStep.CORNER_QUAD -> false
             ScanStep.AUTO_READY -> false
         }
         if (showReticle) {
@@ -278,6 +288,70 @@ fun TableScanScreen(
             }
         }
 
+        // Corner-quad: full-screen tap target + draggable corner handles.
+        if (scanStep == ScanStep.CORNER_QUAD) {
+            val density = LocalDensity.current
+            val handleDp = 32.dp
+            val handlePx = with(density) { handleDp.toPx() }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .pointerInput(cornerTaps.size) {
+                        detectTapGestures { offset ->
+                            if (viewModel.cornerTaps.value.size < 4) {
+                                viewModel.onCornerTap(AndroidPointF(offset.x, offset.y))
+                            }
+                        }
+                    }
+            )
+
+            // Connecting lines between placed corners (light visual guide).
+            if (cornerTaps.isNotEmpty()) {
+                Canvas(modifier = Modifier.fillMaxSize()) {
+                    val ordered = cornerTaps
+                    for (i in ordered.indices) {
+                        val a = ordered[i]
+                        val b = ordered[(i + 1) % ordered.size]
+                        if (ordered.size > 1 && i < ordered.size - 1 || ordered.size == 4) {
+                            drawLine(
+                                color = Color.Yellow.copy(alpha = 0.4f),
+                                start = Offset(a.x, a.y),
+                                end = Offset(b.x, b.y),
+                                strokeWidth = 2.dp.toPx()
+                            )
+                        }
+                    }
+                }
+            }
+
+            cornerTaps.forEachIndexed { idx, pt ->
+                Box(
+                    modifier = Modifier
+                        .offset {
+                            IntOffset(
+                                (pt.x - handlePx / 2f).roundToInt(),
+                                (pt.y - handlePx / 2f).roundToInt()
+                            )
+                        }
+                        .size(handleDp)
+                        .clip(CircleShape)
+                        .background(Color.Yellow.copy(alpha = 0.5f))
+                        .border(2.dp, Color.White, CircleShape)
+                        .pointerInput(idx) {
+                            detectDragGestures { change, drag ->
+                                change.consume()
+                                val current = viewModel.cornerTaps.value.getOrNull(idx) ?: return@detectDragGestures
+                                viewModel.onCornerDrag(
+                                    idx,
+                                    AndroidPointF(current.x + drag.x, current.y + drag.y)
+                                )
+                            }
+                        }
+                )
+            }
+        }
+
         // Felt display circle: appears once capture is done, fades out after 1 second.
         if (scanStep == ScanStep.FELT_CAPTURE) {
             capturedHsv?.let { hsv ->
@@ -294,7 +368,7 @@ fun TableScanScreen(
         }
 
         // Bottom Controls: hidden once capture is in progress or complete.
-        if (!isCapturing && (capturedHsv == null || scanStep == ScanStep.POCKET_GUIDE)) {
+        if (!isCapturing && (capturedHsv == null || scanStep == ScanStep.POCKET_GUIDE || scanStep == ScanStep.CORNER_QUAD)) {
             Column(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
@@ -390,6 +464,69 @@ fun TableScanScreen(
                                         viewModel.captureCurrentPocket()
                                     }
                             )
+                        }
+                    }
+
+                    ScanStep.CORNER_QUAD -> {
+                        val placed = cornerTaps.size
+                        Text(
+                            text = when {
+                                placed == 0 -> "Tap the four corner pockets"
+                                placed < 4 -> "Tap the next corner pocket ($placed of 4)"
+                                else -> "Drag a corner to refine, then confirm"
+                            },
+                            color = Color.White,
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(bottom = 12.dp)
+                        )
+
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            modifier = Modifier.padding(bottom = 16.dp)
+                        ) {
+                            repeat(4) { i ->
+                                Box(
+                                    modifier = Modifier
+                                        .size(14.dp)
+                                        .clip(CircleShape)
+                                        .background(if (i < placed) Color.Green else Color.White.copy(alpha = 0.4f))
+                                        .border(1.dp, Color.White, CircleShape)
+                                )
+                            }
+                        }
+
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(24.dp)
+                        ) {
+                            TextButton(onClick = { viewModel.clearCornerTaps() }) {
+                                Text("Reset", color = Color.White)
+                            }
+                            Box(modifier = Modifier.size(80.dp).padding(4.dp)) {
+                                Canvas(modifier = Modifier.fillMaxSize()) {
+                                    drawCircle(color = Color.White.copy(alpha = 0.2f), style = Stroke(width = 4.dp.toPx()))
+                                    drawArc(
+                                        color = if (placed == 4) Color.Green else Color.Yellow,
+                                        startAngle = -90f, sweepAngle = 360f * (placed / 4f),
+                                        useCenter = false, style = Stroke(width = 4.dp.toPx())
+                                    )
+                                }
+                                Box(
+                                    modifier = Modifier
+                                        .align(Alignment.Center).size(64.dp).clip(CircleShape)
+                                        .background(if (placed == 4) Color.White else Color.LightGray.copy(alpha = 0.5f))
+                                        .border(4.dp, Color.LightGray, CircleShape)
+                                        .clickable(enabled = placed == 4) {
+                                            val haptic = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                                                HapticFeedbackConstants.CONFIRM
+                                            } else {
+                                                HapticFeedbackConstants.LONG_PRESS
+                                            }
+                                            view.performHapticFeedback(haptic)
+                                            viewModel.completeCornerScan()
+                                        }
+                                )
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanViewModel.kt
@@ -42,6 +42,7 @@ private const val CLUSTER_MERGE_DISTANCE = 3.0f
 
 enum class ScanStep {
     FELT_CAPTURE,
+    CORNER_QUAD,
     POCKET_GUIDE,
     AUTO_READY
 }
@@ -87,6 +88,14 @@ class TableScanViewModel @Inject constructor(
 
     private val _capturedFeltHsv = MutableStateFlow<FloatArray?>(null)
     val capturedFeltHsv: StateFlow<FloatArray?> = _capturedFeltHsv.asStateFlow()
+
+    /**
+     * Corner-quad scan: up to 4 screen-space tap positions for the four corner pockets.
+     * Order in the list maps to TL, TR, BR, BL once committed. While the user is tapping,
+     * positions are appended in tap order; on commit they are reordered by screen geometry.
+     */
+    private val _cornerTaps = MutableStateFlow<List<PointF>>(emptyList())
+    val cornerTaps: StateFlow<List<PointF>> = _cornerTaps.asStateFlow()
 
     private val _selectedSampleIds = MutableStateFlow<Set<String>>(emptySet())
     val selectedSampleIds: StateFlow<Set<String>> = _selectedSampleIds.asStateFlow()
@@ -410,6 +419,7 @@ class TableScanViewModel @Inject constructor(
         _currentPocketTarget.value = null
         _mlConfidence.value = 0f
         _mlTableBoundary.value = null
+        _cornerTaps.value = emptyList()
         tableScanRepository.clearPartialScan()
     }
 
@@ -488,9 +498,82 @@ class TableScanViewModel @Inject constructor(
             
             _capturedFeltHsv.value = lastFeltHsv
 
-            // Instead of finishing, transition to Guided Pocket mode
-            _scanStep.value = ScanStep.POCKET_GUIDE
-            _currentPocketTarget.value = PocketId.entries.toTypedArray()[0]
+            // Skip the painful per-pocket wizard; users tap the four corner pockets directly.
+            _cornerTaps.value = emptyList()
+            _scanStep.value = ScanStep.CORNER_QUAD
+            _currentPocketTarget.value = null
+        }
+    }
+
+    fun onCornerTap(screenPoint: PointF) {
+        if (_scanStep.value != ScanStep.CORNER_QUAD) return
+        val current = _cornerTaps.value
+        if (current.size >= 4) return
+        _cornerTaps.value = current + screenPoint
+    }
+
+    fun onCornerDrag(index: Int, screenPoint: PointF) {
+        if (_scanStep.value != ScanStep.CORNER_QUAD) return
+        val current = _cornerTaps.value
+        if (index !in current.indices) return
+        _cornerTaps.value = current.toMutableList().also { it[index] = screenPoint }
+    }
+
+    fun clearCornerTaps() {
+        _cornerTaps.value = emptyList()
+    }
+
+    /**
+     * Sorts four screen-space corner taps into TL/TR/BR/BL order based on their
+     * geometric position relative to the centroid.
+     */
+    private fun sortCornersClockwise(corners: List<PointF>): List<PointF> {
+        if (corners.size != 4) return corners
+        val cx = corners.sumOf { it.x.toDouble() }.toFloat() / 4f
+        val cy = corners.sumOf { it.y.toDouble() }.toFloat() / 4f
+        val top = corners.filter { it.y < cy }.sortedBy { it.x }
+        val bottom = corners.filter { it.y >= cy }.sortedByDescending { it.x }
+        return (top + bottom).take(4)
+    }
+
+    /**
+     * Commit the four corner taps. Maps each screen point to logical space,
+     * derives the two side pockets from the long-side midpoints, fits a homography,
+     * and completes the scan.
+     */
+    fun completeCornerScan() {
+        val inverse = inversePitchMatrix ?: return
+        val taps = _cornerTaps.value
+        if (taps.size != 4) return
+
+        viewModelScope.launch {
+            val sorted = sortCornersClockwise(taps)
+            val tl = Perspective.screenToLogical(sorted[0], inverse)
+            val tr = Perspective.screenToLogical(sorted[1], inverse)
+            val br = Perspective.screenToLogical(sorted[2], inverse)
+            val bl = Perspective.screenToLogical(sorted[3], inverse)
+
+            // Side pockets sit on the long rails. The Table model places them
+            // off the left and right sides of the logical rectangle, so we mirror
+            // that by taking the midpoint of the corresponding short-side corners.
+            val sl = PointF((tl.x + bl.x) / 2f, (tl.y + bl.y) / 2f)
+            val sr = PointF((tr.x + br.x) / 2f, (tr.y + br.y) / 2f)
+
+            val identified = mapOf(
+                PocketId.TL to tl,
+                PocketId.TR to tr,
+                PocketId.BR to br,
+                PocketId.BL to bl,
+                PocketId.SL to sl,
+                PocketId.SR to sr,
+            )
+
+            synchronized(clustersLock) {
+                clusters.clear()
+                identified.forEach { (id, pt) -> clusters[id] = mutableListOf(pt) }
+            }
+            _scanProgress.value = identified.keys.associateWith { true }
+            completeScan(identified)
         }
     }
 

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanViewModel.kt
@@ -553,9 +553,12 @@ class TableScanViewModel @Inject constructor(
             val br = Perspective.screenToLogical(sorted[2], inverse)
             val bl = Perspective.screenToLogical(sorted[3], inverse)
 
-            // Side pockets sit on the long rails. The Table model places them
-            // off the left and right sides of the logical rectangle, so we mirror
-            // that by taking the midpoint of the corresponding short-side corners.
+            // SL/SR are the two side pockets, which sit at the midpoints of the
+            // long rails. The left long rail runs TL→BL, so SL is the midpoint of
+            // those two corners; the right long rail runs TR→BR, so SR is the
+            // midpoint of those. (The Table model nudges each side pocket slightly
+            // off-rail for rendering, but that visual offset is not needed here —
+            // the geometry fit only sees the centre lines.)
             val sl = PointF((tl.x + bl.x) / 2f, (tl.y + bl.y) / 2f)
             val sr = PointF((tr.x + br.x) / 2f, (tr.y + br.y) / 2f)
 


### PR DESCRIPTION
## Summary

Two independent tracks addressing the brainstorm: ball detection failing in dynamic beginner mode, and the painful 6-pocket sequential-tap flow that can't survive real bar lighting.

### Track A — beginner ball detection
- **Root cause found:** `VisionRepository`'s size filter rejects every valid ML detection when no table pose is set. `getExpectedRadiusAtImageY` returns `LOGICAL_BALL_RADIUS` (25 logical units) and that value is compared against pixel-space bounding-box area. Real balls (60–120 px diameter on a phone) never fit. The ML model was working; the post-filter was throwing everything away.
- **Fix:** when no pitch matrix exists, switch to an absolute pixel-side range (10–400 px). When the contour refiner returns null, keep the ML box centre instead of dropping the detection.
- **`FeltColorDetector`:** auto-detects felt HSV from the largest chromatic connected component. No user tap, no table pose dependency, works on any felt color.
- **`CvBallDetector`:** classical pipeline (felt mask → close → subtract → connected components → Hough circles → cue/8/solid/stripe classification) that runs alongside ML. ML wins on overlap, CV fills gaps.

### Track B — 4-corner-tap table scan
- New `CORNER_QUAD` `ScanStep`. User taps four corner pockets in any order; each tap places a draggable handle; side pockets are inferred from the long-rail midpoints.
- Confirm builds a 4-point homography (8 DOF, exact fit) and feeds it through the existing `completeScan` path — rest of AR pipeline is unchanged.
- `captureFeltAndComplete` now advances to `CORNER_QUAD` instead of `POCKET_GUIDE`. The 6-tap wizard stays available via `startManualHoleCapture` for fallback/debug.

### Deferred
ARCore depth-anchor world-space persistence (the "raycast taps into depth map, anchor table rectangle, never lose it" approach) is scaffolded but not in this PR. The existing homography path is reused for now. Follow-up.

## Test plan
- [ ] Beginner mode in a bar / similar lighting: balls now have markers drawn on them
- [ ] Beginner mode in daylight: no regressions in ML detection quality
- [ ] CvBallDetector activates when ML misses balls (verify by tweaking ML confidence threshold)
- [ ] FeltColorDetector handles non-green felt (red, blue, tan)
- [ ] 4-corner-tap: tap four corners in any order, drag to refine, confirm — table appears correctly aligned
- [ ] 4-corner-tap with three taps: confirm button stays disabled
- [ ] Reset button clears corner taps
- [ ] Resume partial scan (kill app mid-scan) still works for POCKET_GUIDE path
- [ ] AR_ACTIVE mode still tracks the table after CORNER_QUAD completion
- [ ] No null/empty Mat crashes when felt detection fails

## Known follow-ups
- ARCore depth-anchor persistence (cache world pose, relocalize on tracking pause, only clear on explicit user reset)
- ROI-cropped CV ball detection inside the locked table polygon for expert mode
- Drop dead `POCKET_GUIDE` flow once `CORNER_QUAD` is verified in production

https://claude.ai/code/session_01PuYATALnYRuo6pDtsgZwWn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuYATALnYRuo6pDtsgZwWn)_