### PR TITLE
cv: fix Float/Double mismatch in CvBallDetector Scalar bounds

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/data/CvBallDetector.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/CvBallDetector.kt
@@ -69,13 +69,13 @@ class CvBallDetector {
         val sdScale = 2.5f
         val lower = Scalar(
             max(0.0, feltHsv[0] - sdScale * feltStdDev[0] - 5.0),
-            max(40.0, feltHsv[1] - sdScale * feltStdDev[1]),
-            max(40.0, feltHsv[2] - sdScale * feltStdDev[2]),
+            max(40.0, (feltHsv[1] - sdScale * feltStdDev[1]).toDouble()),
+            max(40.0, (feltHsv[2] - sdScale * feltStdDev[2]).toDouble()),
         )
         val upper = Scalar(
             min(180.0, feltHsv[0] + sdScale * feltStdDev[0] + 5.0),
-            min(255.0, feltHsv[1] + sdScale * feltStdDev[1]),
-            min(255.0, feltHsv[2] + sdScale * feltStdDev[2]),
+            min(255.0, (feltHsv[1] + sdScale * feltStdDev[1]).toDouble()),
+            min(255.0, (feltHsv[2] + sdScale * feltStdDev[2]).toDouble()),
         )
 
         Core.inRange(hsvMat, lower, upper, feltMask)


### PR DESCRIPTION
Kotlin's max/min require both args be the same numeric type. feltHsv[1] and feltStdDev[1] are Float, so the lower/upper Scalar bound expressions for the S and V channels were producing Float, but the matching literal (40.0/255.0) was Double. Coerce the Float subexpressions to Double so the result type is consistent with the literals and Scalar's Double constructor.

## Summary by Sourcery

Bug Fixes:
- Ensure HSV S and V channel bounds use consistent Double types to avoid Kotlin max/min numeric type mismatches in ball detection.