### PR TITLE
fix(snap): make target/cue ball snapping user-initiated and reversible

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/domain/reducers/GestureReducer.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/domain/reducers/GestureReducer.kt
@@ -211,24 +211,56 @@ class GestureReducer @Inject constructor() {
                 // releases. The anchor is updated to match so the
                 // SnapReducer's frame-to-frame follow does not yank the ball
                 // back to a previous selection.
+                //
+                // Hot path — runs on every drag delta. Walk the typed-ball
+                // list with a single pass that respects the targetType
+                // filter, then fall back to the untyped lists in place
+                // instead of materialising a concatenated list.
                 val visionData = currentState.visionData
                 val snapThreshold = LOGICAL_BALL_RADIUS * 1.5f
-                val closestTyped = visionData?.balls?.asSequence()?.filter {
-                    it.type == BallType.UNKNOWN ||
-                    (currentState.targetType == TargetType.STRIPES && it.type == BallType.STRIPE) ||
-                    (currentState.targetType == TargetType.SOLIDS && it.type == BallType.SOLID)
-                }?.minByOrNull { getDistance(newCenter, it.position) }
+                var closestTypedPos: PointF? = null
+                var closestTypedBox: android.graphics.Rect? = null
+                var closestTypedDist = Float.MAX_VALUE
+                visionData?.balls?.forEach { ball ->
+                    val matches = ball.type == BallType.UNKNOWN ||
+                        (currentState.targetType == TargetType.STRIPES && ball.type == BallType.STRIPE) ||
+                        (currentState.targetType == TargetType.SOLIDS && ball.type == BallType.SOLID)
+                    if (!matches) return@forEach
+                    val d = getDistance(newCenter, ball.position)
+                    if (d < closestTypedDist) {
+                        closestTypedDist = d
+                        closestTypedPos = ball.position
+                        closestTypedBox = ball.boundingBox
+                    }
+                }
+
+                val typedHit = closestTypedPos
                 val snapResult: Triple<PointF, android.graphics.Rect?, PointF?> =
-                    if (closestTyped != null && getDistance(newCenter, closestTyped.position) < snapThreshold) {
-                        Triple(closestTyped.position, closestTyped.boundingBox, closestTyped.position)
+                    if (typedHit != null && closestTypedDist < snapThreshold) {
+                        Triple(typedHit, closestTypedBox, typedHit)
                     } else {
                         // Fall back to position-only candidates (no bbox / no
-                        // type) and only snap if dragged close.
-                        val positions = (visionData?.genericBalls ?: emptyList()) +
-                                (visionData?.customBalls ?: emptyList())
-                        val closestPos = positions.minByOrNull { getDistance(newCenter, it) }
-                        if (closestPos != null && getDistance(newCenter, closestPos) < snapThreshold) {
-                            Triple(closestPos, null, closestPos)
+                        // type). Walk each list in place.
+                        var closestPos: PointF? = null
+                        var closestDist = Float.MAX_VALUE
+                        visionData?.genericBalls?.forEach { p ->
+                            val d = getDistance(newCenter, p)
+                            if (d < closestDist) {
+                                closestDist = d
+                                closestPos = p
+                            }
+                        }
+                        @Suppress("DEPRECATION")
+                        visionData?.customBalls?.forEach { p ->
+                            val d = getDistance(newCenter, p)
+                            if (d < closestDist) {
+                                closestDist = d
+                                closestPos = p
+                            }
+                        }
+                        val fallbackHit = closestPos
+                        if (fallbackHit != null && closestDist < snapThreshold) {
+                            Triple(fallbackHit, null, fallbackHit)
                         } else {
                             // User dragged away from any detected ball: drop
                             // the anchor entirely so the SnapReducer doesn't
@@ -269,16 +301,41 @@ class GestureReducer @Inject constructor() {
                     // near a detected ball, release on drag-away. The anchor
                     // mirrors the snap decision so the SnapReducer's
                     // frame-to-frame follow respects the user's intent.
-                    val positions = (currentState.visionData?.balls?.map { b -> b.position }
-                        ?: emptyList()) +
-                        (currentState.visionData?.genericBalls ?: emptyList()) +
-                        (currentState.visionData?.customBalls ?: emptyList())
+                    //
+                    // Hot path — runs on every drag delta. Walk the three
+                    // candidate lists in place to avoid the allocations from
+                    // building a concatenated list every frame.
                     val snapThreshold = LOGICAL_BALL_RADIUS * 1.5f
-                    val closest = positions.minByOrNull { p -> getDistance(newCenter, p) }
-                    val (snappedCenter, newAnchor) = if (
-                        closest != null && getDistance(newCenter, closest) < snapThreshold
-                    ) {
-                        closest to closest
+                    var closest: PointF? = null
+                    var minDistance = Float.MAX_VALUE
+                    currentState.visionData?.let { vision ->
+                        vision.balls.forEach { b ->
+                            val d = getDistance(newCenter, b.position)
+                            if (d < minDistance) {
+                                minDistance = d
+                                closest = b.position
+                            }
+                        }
+                        vision.genericBalls.forEach { p ->
+                            val d = getDistance(newCenter, p)
+                            if (d < minDistance) {
+                                minDistance = d
+                                closest = p
+                            }
+                        }
+                        @Suppress("DEPRECATION")
+                        vision.customBalls.forEach { p ->
+                            val d = getDistance(newCenter, p)
+                            if (d < minDistance) {
+                                minDistance = d
+                                closest = p
+                            }
+                        }
+                    }
+
+                    val resolved = closest
+                    val (snappedCenter, newAnchor) = if (resolved != null && minDistance < snapThreshold) {
+                        resolved to resolved
                     } else {
                         newCenter to null
                     }

--- a/app/src/main/java/com/hereliesaz/cuedetat/domain/reducers/GestureReducer.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/domain/reducers/GestureReducer.kt
@@ -212,16 +212,12 @@ class GestureReducer @Inject constructor() {
                 // SnapReducer's frame-to-frame follow does not yank the ball
                 // back to a previous selection.
                 val visionData = currentState.visionData
-                val typedCandidates = visionData?.balls
-                    ?.filter {
-                        it.type == BallType.UNKNOWN ||
-                        (currentState.targetType == TargetType.STRIPES && it.type == BallType.STRIPE) ||
-                        (currentState.targetType == TargetType.SOLIDS && it.type == BallType.SOLID)
-                    }
-                    ?: emptyList()
-
                 val snapThreshold = LOGICAL_BALL_RADIUS * 1.5f
-                val closestTyped = typedCandidates.minByOrNull { getDistance(newCenter, it.position) }
+                val closestTyped = visionData?.balls?.asSequence()?.filter {
+                    it.type == BallType.UNKNOWN ||
+                    (currentState.targetType == TargetType.STRIPES && it.type == BallType.STRIPE) ||
+                    (currentState.targetType == TargetType.SOLIDS && it.type == BallType.SOLID)
+                }?.minByOrNull { getDistance(newCenter, it.position) }
                 val snapResult: Triple<PointF, android.graphics.Rect?, PointF?> =
                     if (closestTyped != null && getDistance(newCenter, closestTyped.position) < snapThreshold) {
                         Triple(closestTyped.position, closestTyped.boundingBox, closestTyped.position)

--- a/app/src/main/java/com/hereliesaz/cuedetat/domain/reducers/GestureReducer.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/domain/reducers/GestureReducer.kt
@@ -41,7 +41,11 @@ class GestureReducer @Inject constructor() {
 
         val zoomLimits = ZoomMapping.getZoomRange(currentState.experienceMode, currentState.isBeginnerViewLocked)
         val currentZoom = ZoomMapping.sliderToZoom(currentState.zoomSliderPosition, zoomLimits.first, zoomLimits.second)
-        val touchRadius = (25f * 4.0f) / currentZoom
+        // Generous hit area for ball-drag vs aiming-rotation. The user has the
+        // entire rest of the screen for rotation, so a near-hit on a ball
+        // should pick the ball.
+        val ballDragHitRadius = (LOGICAL_BALL_RADIUS * 8.0f) / currentZoom
+        val touchRadius = ballDragHitRadius
 
         // 0. Ball Selection Phase: tap near a confirmed snap candidate to attach a virtual ball
         if (currentState.tableScanModel != null &&
@@ -97,6 +101,8 @@ class GestureReducer @Inject constructor() {
             if (closestBall != null && getDistance(event.logicalPoint, closestBall) < snapThreshold) {
                 return currentState.copy(
                     protractorUnit = currentState.protractorUnit.copy(center = closestBall),
+                    targetCvAnchor = closestBall,
+                    hasTargetBallBeenMoved = true,
                     interactionMode = InteractionMode.NONE,
                     valuesChangedSinceReset = true
                 )
@@ -199,49 +205,50 @@ class GestureReducer @Inject constructor() {
                     currentState.protractorUnit.center.x + dx,
                     currentState.protractorUnit.center.y + dy
                 )
-                
-                // Snapping logic for Dynamic Beginner Mode. We keep the full
-                // DetectedBall (not just its position) so we can also adjust the
-                // camera zoom to match the snapped ball's apparent size.
-                val isDynamicBeginner = currentState.experienceMode == ExperienceMode.BEGINNER &&
-                        !currentState.isBeginnerViewLocked
-                val snapResult = if (isDynamicBeginner) {
-                    val visionData = currentState.visionData
-                    val typedCandidates = visionData?.balls
-                        ?.filter {
-                            it.type == BallType.UNKNOWN ||
-                            (currentState.targetType == TargetType.STRIPES && it.type == BallType.STRIPE) ||
-                            (currentState.targetType == TargetType.SOLIDS && it.type == BallType.SOLID)
-                        }
-                        ?: emptyList()
 
-                    val snapThreshold = LOGICAL_BALL_RADIUS * 1.5f
-                    val closestTyped = typedCandidates.minByOrNull { getDistance(newCenter, it.position) }
+                // Drag-driven snap: when the user pulls the target ball near a
+                // detected ball, snap to it. When they pull it away, snap
+                // releases. The anchor is updated to match so the
+                // SnapReducer's frame-to-frame follow does not yank the ball
+                // back to a previous selection.
+                val visionData = currentState.visionData
+                val typedCandidates = visionData?.balls
+                    ?.filter {
+                        it.type == BallType.UNKNOWN ||
+                        (currentState.targetType == TargetType.STRIPES && it.type == BallType.STRIPE) ||
+                        (currentState.targetType == TargetType.SOLIDS && it.type == BallType.SOLID)
+                    }
+                    ?: emptyList()
+
+                val snapThreshold = LOGICAL_BALL_RADIUS * 1.5f
+                val closestTyped = typedCandidates.minByOrNull { getDistance(newCenter, it.position) }
+                val snapResult: Triple<PointF, android.graphics.Rect?, PointF?> =
                     if (closestTyped != null && getDistance(newCenter, closestTyped.position) < snapThreshold) {
-                        closestTyped.position to closestTyped.boundingBox
+                        Triple(closestTyped.position, closestTyped.boundingBox, closestTyped.position)
                     } else {
-                        // Fall back to position-only candidates if the typed
-                        // list didn't yield a snap.
+                        // Fall back to position-only candidates (no bbox / no
+                        // type) and only snap if dragged close.
                         val positions = (visionData?.genericBalls ?: emptyList()) +
                                 (visionData?.customBalls ?: emptyList())
                         val closestPos = positions.minByOrNull { getDistance(newCenter, it) }
                         if (closestPos != null && getDistance(newCenter, closestPos) < snapThreshold) {
-                            closestPos to null
+                            Triple(closestPos, null, closestPos)
                         } else {
-                            newCenter to null
+                            // User dragged away from any detected ball: drop
+                            // the anchor entirely so the SnapReducer doesn't
+                            // pull the ball back.
+                            Triple(newCenter, null, null)
                         }
                     }
-                } else {
-                    newCenter to null
-                }
 
                 val snappedCenter = snapResult.first
                 val snappedBox = snapResult.second
+                val newAnchor = snapResult.third
 
-                // If we snapped to a ball with a known bounding box, update the
-                // zoom so the on-screen target ball matches the detected ball's
-                // apparent radius. Position-only snaps (no bbox) leave zoom alone.
-                val newZoomSlider = if (snappedBox != null) {
+                // Adjust zoom only for dynamic beginner snaps with a real bbox.
+                val isDynamicBeginner = currentState.experienceMode == ExperienceMode.BEGINNER &&
+                        !currentState.isBeginnerViewLocked
+                val newZoomSlider = if (isDynamicBeginner && snappedBox != null) {
                     computeSnapZoomSlider(currentState, snappedCenter, snappedBox)
                 } else {
                     currentState.zoomSliderPosition
@@ -249,7 +256,9 @@ class GestureReducer @Inject constructor() {
 
                 currentState.copy(
                     protractorUnit = currentState.protractorUnit.copy(center = snappedCenter),
+                    targetCvAnchor = newAnchor,
                     zoomSliderPosition = newZoomSlider,
+                    hasTargetBallBeenMoved = true,
                     magnifierSourceCenter = updatedMagnifierCenter,
                     valuesChangedSinceReset = true
                 )
@@ -258,8 +267,30 @@ class GestureReducer @Inject constructor() {
                 currentState.onPlaneBall?.let {
                     val dx = event.currentLogicalPoint.x - event.previousLogicalPoint.x
                     val dy = event.currentLogicalPoint.y - event.previousLogicalPoint.y
+                    val newCenter = PointF(it.center.x + dx, it.center.y + dy)
+
+                    // Drag-driven snap for the cue ball: snap when dragged
+                    // near a detected ball, release on drag-away. The anchor
+                    // mirrors the snap decision so the SnapReducer's
+                    // frame-to-frame follow respects the user's intent.
+                    val positions = (currentState.visionData?.balls?.map { b -> b.position }
+                        ?: emptyList()) +
+                        (currentState.visionData?.genericBalls ?: emptyList()) +
+                        (currentState.visionData?.customBalls ?: emptyList())
+                    val snapThreshold = LOGICAL_BALL_RADIUS * 1.5f
+                    val closest = positions.minByOrNull { p -> getDistance(newCenter, p) }
+                    val (snappedCenter, newAnchor) = if (
+                        closest != null && getDistance(newCenter, closest) < snapThreshold
+                    ) {
+                        closest to closest
+                    } else {
+                        newCenter to null
+                    }
+
                     currentState.copy(
-                        onPlaneBall = it.copy(center = PointF(it.center.x + dx, it.center.y + dy)),
+                        onPlaneBall = it.copy(center = snappedCenter),
+                        cueBallCvAnchor = newAnchor,
+                        hasCueBallBeenMoved = true,
                         magnifierSourceCenter = updatedMagnifierCenter,
                         valuesChangedSinceReset = true
                     )

--- a/app/src/main/java/com/hereliesaz/cuedetat/view/renderer/ball/BallRenderer.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/view/renderer/ball/BallRenderer.kt
@@ -475,15 +475,38 @@ class BallRenderer {
         val visionData = state.visionData ?: return
         if (visionData.sourceImageWidth == 0) return
 
-        // Prefer the typed ball list so we can colour by classification. Fall
-        // back to the untyped boundingBoxes when classification hasn't run yet
-        // (e.g. raw OpenCV path with no per-ball type info).
-        val typedBoxes = visionData.balls.mapNotNull { ball ->
-            ball.boundingBox?.let { it to ball.type }
-        }
+        // Every detected ball must show a bounding box. If a ball is missing
+        // one (legacy path), synthesise a square box around its image-space
+        // centre using the median ball box size so the user gets a visible
+        // marker on EVERY ball the ML or CV pipeline produced.
+        val typedBoxesWithFallback: List<Pair<android.graphics.Rect, com.hereliesaz.cuedetat.data.BallType>> =
+            run {
+                val withBoxes = visionData.balls.filter { it.boundingBox != null }
+                val medianSide: Int = withBoxes
+                    .mapNotNull { it.boundingBox }
+                    .map { minOf(it.width(), it.height()) }
+                    .filter { it > 0 }
+                    .sorted()
+                    .let { if (it.isEmpty()) 0 else it[it.size / 2] }
+                val fallbackHalfSide = if (medianSide > 0) medianSide / 2 else 0
+
+                visionData.balls.map { ball ->
+                    val box = ball.boundingBox
+                        ?: if (fallbackHalfSide > 0) {
+                            android.graphics.Rect(
+                                (ball.position.x - fallbackHalfSide).toInt(),
+                                (ball.position.y - fallbackHalfSide).toInt(),
+                                (ball.position.x + fallbackHalfSide).toInt(),
+                                (ball.position.y + fallbackHalfSide).toInt(),
+                            )
+                        } else null
+                    box?.let { it to ball.type }
+                }.filterNotNull()
+            }
+
         val boxes: List<Pair<android.graphics.Rect, com.hereliesaz.cuedetat.data.BallType>> =
-            if (typedBoxes.isNotEmpty()) {
-                typedBoxes
+            if (typedBoxesWithFallback.isNotEmpty()) {
+                typedBoxesWithFallback
             } else {
                 visionData.detectedBoundingBoxes.map { it to com.hereliesaz.cuedetat.data.BallType.UNKNOWN }
             }
@@ -495,11 +518,20 @@ class BallRenderer {
         val canvasWidth = canvas.width.toFloat()
         val canvasHeight = canvas.height.toFloat()
 
-        val matrix = Matrix()
-        val srcRect = RectF(0f, 0f, srcWidth, srcHeight)
-        val destRect = RectF(0f, 0f, canvasWidth, canvasHeight)
-        matrix.setRectToRect(srcRect, destRect, Matrix.ScaleToFit.FILL)
-        matrix.postRotate(rotation, canvasWidth / 2f, canvasHeight / 2f)
+        // CameraBackground uses PreviewView.ScaleType.FILL_CENTER, which is
+        // centre-crop with rotation. Reconstruct the same transform here so
+        // bounding boxes land on top of the visible balls instead of being
+        // stretched by FILL.
+        val rotatedW = if (rotation % 180f == 0f) srcWidth else srcHeight
+        val rotatedH = if (rotation % 180f == 0f) srcHeight else srcWidth
+        val scale = maxOf(canvasWidth / rotatedW, canvasHeight / rotatedH)
+
+        val matrix = Matrix().apply {
+            postTranslate(-srcWidth / 2f, -srcHeight / 2f)
+            postRotate(rotation)
+            postScale(scale, scale)
+            postTranslate(canvasWidth / 2f, canvasHeight / 2f)
+        }
 
         val paint = Paint(paints.cvResultPaint).apply {
             style = Paint.Style.STROKE

--- a/app/src/main/java/com/hereliesaz/cuedetat/view/renderer/ball/BallRenderer.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/view/renderer/ball/BallRenderer.kt
@@ -36,6 +36,11 @@ class BallRenderer {
 
     private val textRenderer = BallTextRenderer()
 
+    // Reused per-frame to avoid GC pressure in the bounding-box draw path,
+    // which runs on every camera frame.
+    private val boundingBoxMatrix = Matrix()
+    private val boundingBoxScratch = RectF()
+
     fun draw(canvas: Canvas, state: CueDetatState, paints: PaintCache, typeface: Typeface?, labels: Map<String, String>) {
         val tps = if (state.cameraMode == com.hereliesaz.cuedetat.domain.CameraMode.LITE_AR) null else state.lensWarpTps
         val isBeginnerLocked = state.experienceMode == ExperienceMode.BEGINNER && state.isBeginnerViewLocked
@@ -479,29 +484,31 @@ class BallRenderer {
         // one (legacy path), synthesise a square box around its image-space
         // centre using the median ball box size so the user gets a visible
         // marker on EVERY ball the ML or CV pipeline produced.
-        val typedBoxesWithFallback: List<Pair<android.graphics.Rect, com.hereliesaz.cuedetat.data.BallType>> =
-            run {
-                val withBoxes = visionData.balls.filter { it.boundingBox != null }
-                val medianSide: Int = withBoxes
-                    .mapNotNull { it.boundingBox }
-                    .map { minOf(it.width(), it.height()) }
-                    .filter { it > 0 }
-                    .sorted()
-                    .let { if (it.isEmpty()) 0 else it[it.size / 2] }
-                val fallbackHalfSide = if (medianSide > 0) medianSide / 2 else 0
+        //
+        // Hot path: this runs on every CV frame. Use a sequence for the
+        // median pass to avoid the intermediate filter / map / filter list
+        // allocations, and bail to the legacy detectedBoundingBoxes list
+        // before touching the per-ball loop when there are no typed balls.
+        val balls = visionData.balls
+        val sides: List<Int> = balls.asSequence()
+            .mapNotNull { it.boundingBox }
+            .map { minOf(it.width(), it.height()) }
+            .filter { it > 0 }
+            .sorted()
+            .toList()
+        val fallbackHalfSide = if (sides.isEmpty()) 0 else sides[sides.size / 2] / 2
 
-                visionData.balls.map { ball ->
-                    val box = ball.boundingBox
-                        ?: if (fallbackHalfSide > 0) {
-                            android.graphics.Rect(
-                                (ball.position.x - fallbackHalfSide).toInt(),
-                                (ball.position.y - fallbackHalfSide).toInt(),
-                                (ball.position.x + fallbackHalfSide).toInt(),
-                                (ball.position.y + fallbackHalfSide).toInt(),
-                            )
-                        } else null
-                    box?.let { it to ball.type }
-                }.filterNotNull()
+        val typedBoxesWithFallback: List<Pair<android.graphics.Rect, com.hereliesaz.cuedetat.data.BallType>> =
+            balls.mapNotNull { ball ->
+                val box = ball.boundingBox ?: if (fallbackHalfSide > 0) {
+                    android.graphics.Rect(
+                        (ball.position.x - fallbackHalfSide).toInt(),
+                        (ball.position.y - fallbackHalfSide).toInt(),
+                        (ball.position.x + fallbackHalfSide).toInt(),
+                        (ball.position.y + fallbackHalfSide).toInt(),
+                    )
+                } else null
+                box?.let { it to ball.type }
             }
 
         val boxes: List<Pair<android.graphics.Rect, com.hereliesaz.cuedetat.data.BallType>> =
@@ -521,17 +528,16 @@ class BallRenderer {
         // CameraBackground uses PreviewView.ScaleType.FILL_CENTER, which is
         // centre-crop with rotation. Reconstruct the same transform here so
         // bounding boxes land on top of the visible balls instead of being
-        // stretched by FILL.
+        // stretched by FILL. Reuse the same Matrix instance every frame.
         val rotatedW = if (rotation % 180f == 0f) srcWidth else srcHeight
         val rotatedH = if (rotation % 180f == 0f) srcHeight else srcWidth
         val scale = maxOf(canvasWidth / rotatedW, canvasHeight / rotatedH)
 
-        val matrix = Matrix().apply {
-            postTranslate(-srcWidth / 2f, -srcHeight / 2f)
-            postRotate(rotation)
-            postScale(scale, scale)
-            postTranslate(canvasWidth / 2f, canvasHeight / 2f)
-        }
+        boundingBoxMatrix.reset()
+        boundingBoxMatrix.postTranslate(-srcWidth / 2f, -srcHeight / 2f)
+        boundingBoxMatrix.postRotate(rotation)
+        boundingBoxMatrix.postScale(scale, scale)
+        boundingBoxMatrix.postTranslate(canvasWidth / 2f, canvasHeight / 2f)
 
         val paint = Paint(paints.cvResultPaint).apply {
             style = Paint.Style.STROKE
@@ -541,9 +547,9 @@ class BallRenderer {
 
         boxes.forEach { (box, type) ->
             paint.color = colorForBallType(type).toArgb()
-            val boxRect = RectF(box)
-            matrix.mapRect(boxRect)
-            canvas.drawRect(boxRect, paint)
+            boundingBoxScratch.set(box)
+            boundingBoxMatrix.mapRect(boundingBoxScratch)
+            canvas.drawRect(boundingBoxScratch, paint)
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes four issues with how the target / cue ball interact with ML-detected balls:

- **Snap is now user-initiated and reversible.** The `SnapReducer`'s frame-to-frame anchor follow was yanking the target ball back to a previously-snapped detection even after the user had dragged it away. The drag handler now updates `targetCvAnchor` / `cueBallCvAnchor` to match the snap decision on every drag step: snap-near sets the anchor, drag-away clears it. The anchor follow then respects the user's intent.
- **Generous drag area.** Bumped the ball-grab touch radius from `4 *` to `8 *` `LOGICAL_BALL_RADIUS` so the area around the target / cue / ghost ball comfortably triggers drag; the rest of the screen is free for rotation.
- **Bounding box on every detected ball.** `drawBoundingBoxes` now synthesises a square box from each ball's position + the median observed box size when one is missing, so every detected ball gets a visible marker.
- **Bounding box alignment.** Replaced the `Matrix.ScaleToFit.FILL` stretch with a centre-crop transform that matches the camera preview's `PreviewView.ScaleType.FILL_CENTER`, so boxes land on the visible balls rather than being squashed.

The ghost cue ball stays coupled to the aiming line by construction — its center is derived from `protractorUnit.center` + `rotationDegrees` in `ProtractorUnit.ghostCueBallCenter`. No changes there.

## Test plan

- [ ] Drag the target ball onto a detected ball — it snaps.
- [ ] Drag the target ball away from the snapped ball — it stays where you left it (no rubber-band back).
- [ ] Drag from one detected ball to another — anchor follows the new selection.
- [ ] Drag near (not on) the target ball — drag picks it up.
- [ ] Drag in empty space far from the target ball — aiming rotation, not drag.
- [ ] Confirm bounding boxes appear on every detected ball and align with the visible camera frame.
- [ ] Confirm the ghost cue ball remains tethered to the target ball / aiming line during drag and rotation.

https://claude.ai/code/session_01RqmDFDMFcSoZ2CZJPtDQMY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqmDFDMFcSoZ2CZJPtDQMY)_

## Summary by Sourcery

Make target and cue ball snapping explicitly driven by user drag while improving visualisation of detected balls.

New Features:
- Allow target and cue balls to snap to nearby detected balls during drag with anchors that follow or release based on proximity.
- Show synthesized bounding boxes for detected balls that lack explicit box data so every detected ball is visually marked.

Bug Fixes:
- Ensure target and cue balls no longer rubber-band back to previous detections after the user drags them away by updating or clearing their anchors during drag.

Enhancements:
- Increase the effective drag hit area around balls to make initiating drags easier and keep the rest of the screen available for aiming rotation.
- Align bounding box rendering with the camera preview’s center-crop transform so boxes correctly overlay visible balls.
- Reduce per-frame allocations in ball dragging and bounding-box rendering hot paths to lower GC pressure and improve performance.