### PR TITLE
billing: auto-detect Play account email for tester license + diagnostics

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -125,6 +125,11 @@ val localProps = Properties().apply {
 }
 val googleCloudProjectNumber = localProps.getProperty("GOOGLE_CLOUD_PROJECT_NUMBER") ?: "0"
 val githubAccessToken = localProps.getProperty("GH_TOKEN") ?: ""
+// OAuth 2.0 *Web* client ID from Google Cloud Console. Required by
+// Credential Manager's GetGoogleIdOption. Empty when absent: the tester
+// auto-resolve falls back to no-op so the build still works for
+// contributors who don't have credentials configured.
+val googleOauthWebClientId = localProps.getProperty("GOOGLE_OAUTH_WEB_CLIENT_ID") ?: ""
 
 // Task to write back the updated properties
 tasks.register("updateVersionProperties") {
@@ -187,6 +192,7 @@ android {
         
         buildConfigField("long", "GOOGLE_CLOUD_PROJECT_NUMBER", "${googleCloudProjectNumber}L")
         buildConfigField("String", "GH_TOKEN", "\"$githubAccessToken\"")
+        buildConfigField("String", "GOOGLE_OAUTH_WEB_CLIENT_ID", "\"$googleOauthWebClientId\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -305,10 +311,13 @@ dependencies {
     // Play Billing — only included in the play flavor APK.
     "playImplementation"(libs.androidx.billing.ktx)
 
-    // Google Sign-In — only included in the play flavor APK. Used to read
-    // the device's currently-signed-in Google account email so the app can
-    // match it against the tester-license allowlist baked into the build.
-    "playImplementation"(libs.play.services.auth)
+    // Credential Manager + Google ID — only included in the play flavor APK.
+    // Used to read the device's currently-signed-in Google account email
+    // (via a one-tap account picker on first use) so the app can match it
+    // against the tester-license allowlist baked into the build.
+    "playImplementation"(libs.androidx.credentials)
+    "playImplementation"(libs.androidx.credentials.play.services.auth)
+    "playImplementation"(libs.google.id)
 
     // Core & Jetpack
     implementation(libs.androidx.core.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -305,6 +305,11 @@ dependencies {
     // Play Billing — only included in the play flavor APK.
     "playImplementation"(libs.androidx.billing.ktx)
 
+    // Google Sign-In — only included in the play flavor APK. Used to read
+    // the device's currently-signed-in Google account email so the app can
+    // match it against the tester-license allowlist baked into the build.
+    "playImplementation"(libs.play.services.auth)
+
     // Core & Jetpack
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/java/com/hereliesaz/cuedetat/billing/EntitlementRepository.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/billing/EntitlementRepository.kt
@@ -3,7 +3,6 @@
 package com.hereliesaz.cuedetat.billing
 
 import android.app.Activity
-import android.content.Intent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -58,22 +57,27 @@ interface EntitlementRepository {
     fun diagnostics(): EntitlementDiagnostics = EntitlementDiagnostics(emptyList(), "n/a", false)
 
     /**
-     * Returns a Google Sign-In intent the caller should launch via
-     * [Activity.startActivityForResult] / `rememberLauncherForActivityResult`,
-     * then feed the result back through [applyTesterLicenseFromSignInResult].
+     * Run the Credential Manager one-tap account picker against the
+     * tester-license allowlist. The picker is shown anchored to
+     * `activity`; the resolved email is hashed in memory, never persisted
+     * in plain text. Returns [TesterLicenseResult.Granted] on a match.
      *
-     * Null in FOSS, and null in play if Sign-In isn't available (e.g. Play
-     * Services missing).
+     * No-op (returns NotApplicable) in FOSS, and in play builds that were
+     * assembled without `GOOGLE_OAUTH_WEB_CLIENT_ID` configured.
      */
-    fun googleSignInIntent(): Intent? = null
+    suspend fun resolveTesterLicenseViaCredentialManager(activity: Activity): TesterLicenseResult =
+        TesterLicenseResult.NotApplicable
 
     /**
-     * Pull the Google account email out of a Sign-In activity result and
-     * try the tester-license allowlist against it. Single call so the UI
-     * doesn't have to mention the email at all.
+     * Best-effort silent variant. Only returns Granted if the user has
+     * previously authorized this app for a Google account that happens to
+     * be on the allowlist. Safe to call on app start without prompting.
      */
-    suspend fun applyTesterLicenseFromSignInResult(data: Intent?): TesterLicenseResult =
+    suspend fun silentlyResolveTesterLicense(activity: Activity): TesterLicenseResult =
         TesterLicenseResult.NotApplicable
+
+    /** Whether the Credential Manager flow is available in this build. */
+    val isCredentialManagerAvailable: Boolean get() = false
 }
 
 sealed class TesterLicenseResult {

--- a/app/src/main/java/com/hereliesaz/cuedetat/billing/EntitlementRepository.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/billing/EntitlementRepository.kt
@@ -3,6 +3,7 @@
 package com.hereliesaz.cuedetat.billing
 
 import android.app.Activity
+import android.content.Intent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -42,7 +43,61 @@ interface EntitlementRepository {
      * In FOSS, emits a permanent NotApplicable state.
      */
     fun productDetails(): Flow<ProductDetailsState>
+
+    /**
+     * Try to grant a tester license by matching `email` against the
+     * build-baked allowlist. Returns the result so UI can show feedback.
+     * No-op in FOSS — that flavor is already entitled.
+     */
+    suspend fun applyTesterLicense(email: String): TesterLicenseResult = TesterLicenseResult.NotApplicable
+
+    /** Forget a previously-applied tester license. No-op in FOSS. */
+    suspend fun clearTesterLicense() {}
+
+    /** Public diagnostic snapshot — used by the debug surface in the paywall. */
+    fun diagnostics(): EntitlementDiagnostics = EntitlementDiagnostics(emptyList(), "n/a", false)
+
+    /**
+     * Returns a Google Sign-In intent the caller should launch via
+     * [Activity.startActivityForResult] / `rememberLauncherForActivityResult`,
+     * then feed the result back through [applyTesterLicenseFromSignInResult].
+     *
+     * Null in FOSS, and null in play if Sign-In isn't available (e.g. Play
+     * Services missing).
+     */
+    fun googleSignInIntent(): Intent? = null
+
+    /**
+     * Pull the Google account email out of a Sign-In activity result and
+     * try the tester-license allowlist against it. Single call so the UI
+     * doesn't have to mention the email at all.
+     */
+    suspend fun applyTesterLicenseFromSignInResult(data: Intent?): TesterLicenseResult =
+        TesterLicenseResult.NotApplicable
 }
+
+sealed class TesterLicenseResult {
+    /** Email matched the allowlist; entitlement granted. */
+    object Granted : TesterLicenseResult()
+    /** Email did not match the allowlist baked into this build. */
+    object NotOnAllowlist : TesterLicenseResult()
+    /** This build wasn't assembled with any tester emails (e.g. local dev). */
+    object AllowlistEmpty : TesterLicenseResult()
+    /** Caller passed an empty / malformed email. */
+    object InvalidEmail : TesterLicenseResult()
+    /** FOSS flavor — no tester license concept. */
+    object NotApplicable : TesterLicenseResult()
+}
+
+/**
+ * Snapshot of recent billing state for the in-app diagnostic surface. Strings
+ * only — this is rendered as-is for the user to copy into a bug report.
+ */
+data class EntitlementDiagnostics(
+    val recentPurchaseSnapshots: List<String>,
+    val lastRefreshOutcome: String,
+    val testerAllowlistConfigured: Boolean,
+)
 
 sealed class ProductDetailsState {
     object Loading : ProductDetailsState()

--- a/app/src/main/java/com/hereliesaz/cuedetat/domain/StateReducer.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/domain/StateReducer.kt
@@ -57,7 +57,8 @@ fun stateReducer(
         is MainScreenEvent.EnterCvMaskTestMode, is MainScreenEvent.ExitCvMaskTestMode,
         is MainScreenEvent.StartCalibrationMode, is MainScreenEvent.SampleColorAt,
         is MainScreenEvent.ToggleCvRefinementMethod,
-        is MainScreenEvent.UpdateCannyT1, is MainScreenEvent.UpdateCannyT2 ->
+        is MainScreenEvent.UpdateCannyT1, is MainScreenEvent.UpdateCannyT2,
+        is MainScreenEvent.ToggleBillingDebugDialog ->
             reduceAdvancedOptionsAction(currentState, action)
 
         // --- CONTROLS & TRANSFORMS ---

--- a/app/src/main/java/com/hereliesaz/cuedetat/domain/UiModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/domain/UiModel.kt
@@ -136,6 +136,7 @@ data class CueDetatState(
     val lockedHsvColor: FloatArray? = null,
     val lockedHsvStdDev: FloatArray? = null,
     val showAdvancedOptionsDialog: Boolean = false,
+    val showBillingDebugDialog: Boolean = false,
     val showCalibrationScreen: Boolean = false,
     val showTableScanScreen: Boolean = false,
     val cvRefinementMethod: CvRefinementMethod = CvRefinementMethod.CONTOUR,
@@ -272,6 +273,7 @@ sealed class MainScreenEvent {
     object StartArTracking : MainScreenEvent()
     object ClearSamplePoint : MainScreenEvent()
     object ToggleAdvancedOptionsDialog : MainScreenEvent()
+    object ToggleBillingDebugDialog : MainScreenEvent()
     object ToggleCalibrationScreen : MainScreenEvent()
     data class ApplyQuickAlign(
         val translation: Offset,

--- a/app/src/main/java/com/hereliesaz/cuedetat/domain/reducers/AdvancedOptionsReducer.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/domain/reducers/AdvancedOptionsReducer.kt
@@ -21,6 +21,10 @@ internal fun reduceAdvancedOptionsAction(state: CueDetatState, action: MainScree
             state.copy(showAdvancedOptionsDialog = !state.showAdvancedOptionsDialog)
         }
 
+        is MainScreenEvent.ToggleBillingDebugDialog -> {
+            state.copy(showBillingDebugDialog = !state.showBillingDebugDialog)
+        }
+
         // Enable/Disable the CV mask overlay (seeing the world as the AI does).
         is MainScreenEvent.ToggleCvMask -> {
             state.copy(showCvMask = !state.showCvMask)

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/ProtractorScreen.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/ProtractorScreen.kt
@@ -300,5 +300,13 @@ fun ProtractorScreen(
                 onDismiss = { mainViewModel.onEvent(MainScreenEvent.ToggleTableSizeDialog) }
             )
         }
+
+        onscreen(alignment = Alignment.Center) {
+            if (uiState.showBillingDebugDialog) {
+                com.hereliesaz.cuedetat.ui.composables.dialogs.BillingDebugDialog(
+                    onDismiss = { mainViewModel.onEvent(MainScreenEvent.ToggleBillingDebugDialog) }
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/AzNavRailMenu.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/AzNavRailMenu.kt
@@ -305,6 +305,15 @@ fun AzNavRailMenu(
             azMenuItem(id = "advanced", route = "main", text = "Advanced", fillColor = b1Y, textColor = Color.White, onClick = { onEvent(MainScreenEvent.ToggleAdvancedOptionsDialog) })
         }
 
+        azMenuItem(
+            id = "billing-debug",
+            route = "main",
+            text = "Billing & License",
+            fillColor = b1Y,
+            textColor = Color.White,
+            onClick = { onEvent(MainScreenEvent.ToggleBillingDebugDialog) },
+        )
+
         azDivider()
         azMenuItem(id = "mode", route = "main", text = "Mode: ${uiState.experienceMode?.name}", fillColor = b2B, textColor = Color.White, onClick = { onEvent(MainScreenEvent.ToggleExperienceModeSelection) })
     }

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/dialogs/BillingDebugDialog.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/dialogs/BillingDebugDialog.kt
@@ -1,0 +1,321 @@
+// FILE: app/src/main/java/com/hereliesaz/cuedetat/ui/composables/dialogs/BillingDebugDialog.kt
+
+package com.hereliesaz.cuedetat.ui.composables.dialogs
+
+import android.app.Activity
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hereliesaz.cuedetat.billing.EntitlementDiagnostics
+import com.hereliesaz.cuedetat.billing.EntitlementRepository
+import com.hereliesaz.cuedetat.billing.EntitlementSource
+import com.hereliesaz.cuedetat.billing.TesterLicenseResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Dedicated billing debug screen. Surfaces everything an expert tester
+ * needs to figure out why their purchase / tester license isn't unlocking
+ * Expert. The data shown is read directly from EntitlementRepository so
+ * it always reflects what the app actually sees, not a cached snapshot.
+ */
+@Composable
+fun BillingDebugDialog(
+    onDismiss: () -> Unit,
+    viewModel: BillingDebugViewModel = hiltViewModel(),
+) {
+    val activity = LocalContext.current as? Activity
+    val state by viewModel.uiState.collectAsState()
+    var manualEmail by remember { mutableStateOf("") }
+
+    // Pull a fresh diagnostics snapshot when the dialog opens.
+    LaunchedEffect(Unit) { viewModel.refresh() }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Billing & tester license debug") },
+        text = {
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 480.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                EntitlementBlock(state)
+                HorizontalDivider(Modifier.padding(vertical = 8.dp))
+                TesterLicenseBlock(
+                    state = state,
+                    manualEmail = manualEmail,
+                    onManualEmailChange = { manualEmail = it },
+                    onPickAccount = { activity?.let { viewModel.runInteractivePicker(it) } },
+                    onApplyManual = { viewModel.applyTesterLicenseManually(manualEmail) },
+                    onClear = { viewModel.clearTesterLicense() },
+                )
+                HorizontalDivider(Modifier.padding(vertical = 8.dp))
+                DiagnosticsBlock(state.diagnostics)
+                HorizontalDivider(Modifier.padding(vertical = 8.dp))
+                ActionsBlock(
+                    onRefresh = { viewModel.refresh() },
+                    onRestorePurchases = { viewModel.restorePurchases() },
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        }
+    )
+}
+
+@Composable
+private fun EntitlementBlock(state: BillingDebugUiState) {
+    Text("Current entitlement", style = MaterialTheme.typography.titleSmall)
+    Spacer(Modifier.height(4.dp))
+    KvLine("active", state.entitlementActive.toString())
+    KvLine("source", state.entitlementSource.name)
+    KvLine("productId", state.entitlementProductId ?: "n/a")
+    KvLine("isDeviceGenuine", state.isDeviceGenuine.toString())
+    KvLine("lastVerifiedMillis", state.lastVerifiedAtMillis?.toString() ?: "n/a")
+}
+
+@Composable
+private fun TesterLicenseBlock(
+    state: BillingDebugUiState,
+    manualEmail: String,
+    onManualEmailChange: (String) -> Unit,
+    onPickAccount: () -> Unit,
+    onApplyManual: () -> Unit,
+    onClear: () -> Unit,
+) {
+    Text("Tester license", style = MaterialTheme.typography.titleSmall)
+    Spacer(Modifier.height(4.dp))
+    KvLine(
+        "allowlist baked into APK",
+        if (state.diagnostics.testerAllowlistConfigured) "yes" else "no"
+    )
+    KvLine(
+        "Credential Manager configured",
+        if (state.credentialManagerAvailable) "yes" else "no"
+    )
+
+    Spacer(Modifier.height(8.dp))
+    Row(
+        Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Button(
+            onClick = onPickAccount,
+            modifier = Modifier.weight(1f),
+            enabled = state.credentialManagerAvailable,
+        ) { Text("Pick Google account") }
+        OutlinedButton(
+            onClick = onClear,
+            modifier = Modifier.weight(1f),
+            enabled = state.entitlementSource == EntitlementSource.TESTER_LICENSE,
+        ) { Text("Revoke tester") }
+    }
+
+    Spacer(Modifier.height(8.dp))
+    OutlinedTextField(
+        value = manualEmail,
+        onValueChange = onManualEmailChange,
+        label = { Text("Manual tester email") },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth()
+    )
+    Spacer(Modifier.height(4.dp))
+    Button(
+        onClick = onApplyManual,
+        enabled = manualEmail.contains('@'),
+        modifier = Modifier.fillMaxWidth(),
+    ) { Text("Try tester license") }
+
+    state.lastTesterOutcome?.let { outcome ->
+        Spacer(Modifier.height(8.dp))
+        val msg = when (outcome) {
+            TesterLicenseResult.Granted -> "Granted ✓"
+            TesterLicenseResult.NotOnAllowlist -> "Email is not on this build's allowlist"
+            TesterLicenseResult.AllowlistEmpty -> "Allowlist not configured in this build"
+            TesterLicenseResult.InvalidEmail -> "No email returned / invalid input"
+            TesterLicenseResult.NotApplicable -> "Not applicable (FOSS or no Web Client ID)"
+        }
+        Text(
+            msg,
+            style = MaterialTheme.typography.bodySmall,
+            color = if (outcome == TesterLicenseResult.Granted)
+                MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+        )
+    }
+}
+
+@Composable
+private fun DiagnosticsBlock(diagnostics: EntitlementDiagnostics) {
+    Text("Recent purchase snapshots", style = MaterialTheme.typography.titleSmall)
+    Spacer(Modifier.height(4.dp))
+    Text(
+        "Last refresh: ${diagnostics.lastRefreshOutcome}",
+        style = MaterialTheme.typography.bodySmall,
+        fontFamily = FontFamily.Monospace
+    )
+    Spacer(Modifier.height(4.dp))
+    if (diagnostics.recentPurchaseSnapshots.isEmpty()) {
+        Text(
+            "(none recorded yet — try \"Restore purchases\" below)",
+            style = MaterialTheme.typography.bodySmall,
+        )
+    } else {
+        diagnostics.recentPurchaseSnapshots.forEach { line ->
+            Text(
+                line,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActionsBlock(
+    onRefresh: () -> Unit,
+    onRestorePurchases: () -> Unit,
+) {
+    Text("Actions", style = MaterialTheme.typography.titleSmall)
+    Spacer(Modifier.height(4.dp))
+    Row(
+        Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        OutlinedButton(onClick = onRefresh, modifier = Modifier.weight(1f)) {
+            Text("Refresh state")
+        }
+        OutlinedButton(onClick = onRestorePurchases, modifier = Modifier.weight(1f)) {
+            Text("Restore purchases")
+        }
+    }
+}
+
+@Composable
+private fun KvLine(key: String, value: String) {
+    Row(Modifier.fillMaxWidth()) {
+        Text(
+            "$key:",
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            value,
+            style = MaterialTheme.typography.bodySmall,
+            fontFamily = FontFamily.Monospace,
+            modifier = Modifier.weight(2f),
+        )
+    }
+}
+
+data class BillingDebugUiState(
+    val entitlementActive: Boolean = false,
+    val entitlementSource: EntitlementSource = EntitlementSource.NONE,
+    val entitlementProductId: String? = null,
+    val isDeviceGenuine: Boolean = true,
+    val lastVerifiedAtMillis: Long? = null,
+    val credentialManagerAvailable: Boolean = false,
+    val diagnostics: EntitlementDiagnostics = EntitlementDiagnostics(emptyList(), "not loaded", false),
+    val lastTesterOutcome: TesterLicenseResult? = null,
+)
+
+@HiltViewModel
+class BillingDebugViewModel @Inject constructor(
+    private val repository: EntitlementRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(BillingDebugUiState())
+    val uiState: StateFlow<BillingDebugUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.entitlement.collect { e ->
+                _uiState.value = _uiState.value.copy(
+                    entitlementActive = e.active,
+                    entitlementSource = e.source,
+                    entitlementProductId = e.productId,
+                    isDeviceGenuine = e.isDeviceGenuine,
+                    lastVerifiedAtMillis = e.lastVerifiedAtMillis,
+                )
+            }
+        }
+        refresh()
+    }
+
+    fun refresh() {
+        _uiState.value = _uiState.value.copy(
+            credentialManagerAvailable = repository.isCredentialManagerAvailable,
+            diagnostics = repository.diagnostics(),
+        )
+        viewModelScope.launch { runCatching { repository.refresh() } }
+    }
+
+    fun restorePurchases() {
+        viewModelScope.launch { runCatching { repository.restorePurchases() } }
+        _uiState.value = _uiState.value.copy(diagnostics = repository.diagnostics())
+    }
+
+    fun runInteractivePicker(activity: Activity) {
+        viewModelScope.launch {
+            val outcome = repository.resolveTesterLicenseViaCredentialManager(activity)
+            _uiState.value = _uiState.value.copy(
+                lastTesterOutcome = outcome,
+                diagnostics = repository.diagnostics(),
+            )
+        }
+    }
+
+    fun applyTesterLicenseManually(email: String) {
+        viewModelScope.launch {
+            val outcome = repository.applyTesterLicense(email)
+            _uiState.value = _uiState.value.copy(
+                lastTesterOutcome = outcome,
+                diagnostics = repository.diagnostics(),
+            )
+        }
+    }
+
+    fun clearTesterLicense() {
+        viewModelScope.launch {
+            runCatching { repository.clearTesterLicense() }
+            _uiState.value = _uiState.value.copy(diagnostics = repository.diagnostics())
+        }
+    }
+}

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallSheet.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallSheet.kt
@@ -3,20 +3,28 @@
 package com.hereliesaz.cuedetat.ui.composables.paywall
 
 import android.app.Activity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -24,6 +32,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -31,6 +42,7 @@ import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
@@ -38,6 +50,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.hereliesaz.cuedetat.billing.BasePlanId
 import com.hereliesaz.cuedetat.billing.PaywallTrigger
 import com.hereliesaz.cuedetat.billing.ProductDetailsState
+import com.hereliesaz.cuedetat.billing.TesterLicenseResult
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -132,6 +145,10 @@ fun PaywallSheet(
             TextButton(onClick = { viewModel.restore() }) { Text("Restore Purchases") }
             TextButton(onClick = onDismiss) { Text("Continue in Beginner Mode") }
 
+            HorizontalDivider(Modifier.padding(vertical = 12.dp))
+
+            TesterLicenseSection(viewModel = viewModel, uiState = uiState)
+
             Spacer(Modifier.height(16.dp))
             val githubFooter = buildAnnotatedString {
                 append("Cue D'etat is always available in its entirety for free on ")
@@ -150,6 +167,127 @@ fun PaywallSheet(
                 style = MaterialTheme.typography.bodySmall,
                 modifier = Modifier.padding(top = 8.dp)
             )
+        }
+    }
+}
+
+/**
+ * Tester license + diagnostics block. Lets a user on the closed-testing
+ * Google Group grant themselves Expert without buying — and gives them a
+ * legible view of what Play Billing is actually returning when a real
+ * purchase looks like it isn't being honoured.
+ */
+@Composable
+private fun TesterLicenseSection(
+    viewModel: PaywallViewModel,
+    uiState: PaywallUiState,
+) {
+    val signInIntent = remember(viewModel) { viewModel.googleSignInIntent() }
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        viewModel.applyTesterLicenseFromSignInResult(result.data)
+    }
+
+    var manualEmailExpanded by remember { mutableStateOf(false) }
+    var manualEmail by remember { mutableStateOf("") }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text("Tester / closed beta", style = MaterialTheme.typography.titleSmall)
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "If your Google account is in the project's tester group, you can " +
+                "unlock Expert directly — no purchase needed.",
+            style = MaterialTheme.typography.bodySmall
+        )
+        Spacer(Modifier.height(8.dp))
+
+        if (signInIntent != null) {
+            Button(
+                onClick = { launcher.launch(signInIntent) },
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text("Check via Google Sign-In") }
+        }
+
+        TextButton(onClick = { manualEmailExpanded = !manualEmailExpanded }) {
+            Text(if (manualEmailExpanded) "Hide manual email" else "Use manual email instead")
+        }
+
+        if (manualEmailExpanded) {
+            OutlinedTextField(
+                value = manualEmail,
+                onValueChange = { manualEmail = it },
+                label = { Text("Tester email") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(4.dp))
+            Button(
+                onClick = { viewModel.applyTesterLicenseManually(manualEmail) },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = manualEmail.contains('@'),
+            ) { Text("Try tester license") }
+        }
+
+        val outcome = uiState.testerLicenseOutcome
+        if (outcome != null) {
+            Spacer(Modifier.height(8.dp))
+            val message = when (outcome) {
+                TesterLicenseResult.Granted ->
+                    "Tester license granted. Expert is unlocked."
+                TesterLicenseResult.NotOnAllowlist ->
+                    "That email is not on this build's tester allowlist."
+                TesterLicenseResult.AllowlistEmpty ->
+                    "This build wasn't assembled with a tester allowlist (local / debug build)."
+                TesterLicenseResult.InvalidEmail ->
+                    "Couldn't read an email from the sign-in response."
+                TesterLicenseResult.NotApplicable ->
+                    "Tester license isn't available in this build flavor."
+            }
+            val isGood = outcome == TesterLicenseResult.Granted
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = if (isGood) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+            )
+        }
+
+        Spacer(Modifier.height(8.dp))
+        TextButton(onClick = { viewModel.toggleDiagnostics() }) {
+            Text(if (uiState.showDiagnostics) "Hide billing diagnostics" else "Show billing diagnostics")
+        }
+
+        if (uiState.showDiagnostics) {
+            val d = uiState.diagnostics
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 240.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                Text(
+                    "Allowlist baked into APK: ${if (d.testerAllowlistConfigured) "yes" else "no"}",
+                    style = MaterialTheme.typography.bodySmall
+                )
+                Text(
+                    "Last refresh: ${d.lastRefreshOutcome}",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace
+                )
+                Spacer(Modifier.height(4.dp))
+                Text("Recent purchase snapshots:", style = MaterialTheme.typography.bodySmall)
+                if (d.recentPurchaseSnapshots.isEmpty()) {
+                    Text("  (none recorded yet)", style = MaterialTheme.typography.bodySmall)
+                } else {
+                    d.recentPurchaseSnapshots.forEach {
+                        Text(
+                            "  $it",
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = FontFamily.Monospace
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallSheet.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallSheet.kt
@@ -3,8 +3,6 @@
 package com.hereliesaz.cuedetat.ui.composables.paywall
 
 import android.app.Activity
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,7 +21,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -66,6 +63,13 @@ fun PaywallSheet(
     val uiState by viewModel.uiState.collectAsState()
 
     LaunchedEffect(trigger) { viewModel.setTrigger(trigger) }
+
+    // Silent Credential Manager attempt as soon as we have an Activity. If
+    // the user has already authorized us and their account is on the
+    // allowlist, the paywall will auto-close before they ever see plans.
+    LaunchedEffect(activity) {
+        activity?.let { viewModel.attemptSilentResolveOnce(it) }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.purchaseFlowResults.collect { event ->
@@ -147,7 +151,7 @@ fun PaywallSheet(
 
             HorizontalDivider(Modifier.padding(vertical = 12.dp))
 
-            TesterLicenseSection(viewModel = viewModel, uiState = uiState)
+            TesterLicenseSection(viewModel = viewModel, uiState = uiState, activity = activity)
 
             Spacer(Modifier.height(16.dp))
             val githubFooter = buildAnnotatedString {
@@ -181,14 +185,8 @@ fun PaywallSheet(
 private fun TesterLicenseSection(
     viewModel: PaywallViewModel,
     uiState: PaywallUiState,
+    activity: Activity?,
 ) {
-    val signInIntent = remember(viewModel) { viewModel.googleSignInIntent() }
-    val launcher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        viewModel.applyTesterLicenseFromSignInResult(result.data)
-    }
-
     var manualEmailExpanded by remember { mutableStateOf(false) }
     var manualEmail by remember { mutableStateOf("") }
 
@@ -202,11 +200,11 @@ private fun TesterLicenseSection(
         )
         Spacer(Modifier.height(8.dp))
 
-        if (signInIntent != null) {
+        if (viewModel.isCredentialManagerAvailable && activity != null) {
             Button(
-                onClick = { launcher.launch(signInIntent) },
+                onClick = { viewModel.runInteractivePicker(activity) },
                 modifier = Modifier.fillMaxWidth(),
-            ) { Text("Check via Google Sign-In") }
+            ) { Text("Check via Google account") }
         }
 
         TextButton(onClick = { manualEmailExpanded = !manualEmailExpanded }) {
@@ -240,9 +238,9 @@ private fun TesterLicenseSection(
                 TesterLicenseResult.AllowlistEmpty ->
                     "This build wasn't assembled with a tester allowlist (local / debug build)."
                 TesterLicenseResult.InvalidEmail ->
-                    "Couldn't read an email from the sign-in response."
+                    "Couldn't read an email from the account picker."
                 TesterLicenseResult.NotApplicable ->
-                    "Tester license isn't available in this build flavor."
+                    "Tester license isn't available in this build (no OAuth Web Client ID configured)."
             }
             val isGood = outcome == TesterLicenseResult.Granted
             Text(

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallViewModel.kt
@@ -3,7 +3,6 @@
 package com.hereliesaz.cuedetat.ui.composables.paywall
 
 import android.app.Activity
-import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hereliesaz.cuedetat.billing.BasePlanId
@@ -34,6 +33,12 @@ class PaywallViewModel @Inject constructor(
     val purchaseFlowResults: SharedFlow<PurchaseFlowEvent> = _purchaseFlowResults.asSharedFlow()
 
     private var triggerSnapshot: PaywallTrigger? = null
+
+    /** True once we've kicked off the silent Credential Manager resolve for this paywall session. */
+    private var hasAttemptedSilentResolve = false
+
+    val isCredentialManagerAvailable: Boolean
+        get() = repository.isCredentialManagerAvailable
 
     init {
         viewModelScope.launch {
@@ -79,19 +84,36 @@ class PaywallViewModel @Inject constructor(
         }
     }
 
-    /** Build the Google Sign-In intent the UI should launch. Null = not available. */
-    fun googleSignInIntent(): Intent? = repository.googleSignInIntent()
-
-    /** Consume the result of the Sign-In flow and attempt the allowlist match. */
-    fun applyTesterLicenseFromSignInResult(data: Intent?) {
+    /**
+     * Try a silent (no-UI) Credential Manager resolve as soon as the paywall
+     * sheet is composed with an Activity context. If the user has previously
+     * authorized this app for a Google account that's on the allowlist, this
+     * grants Expert without ever showing the picker.
+     */
+    fun attemptSilentResolveOnce(activity: Activity) {
+        if (hasAttemptedSilentResolve) return
+        hasAttemptedSilentResolve = true
         viewModelScope.launch {
-            val outcome = repository.applyTesterLicenseFromSignInResult(data)
+            val outcome = repository.silentlyResolveTesterLicense(activity)
+            // Only surface a UX message for actual grants; silent failures
+            // are expected and the paywall just continues to show plans.
+            if (outcome == TesterLicenseResult.Granted) {
+                _uiState.value = _uiState.value.copy(testerLicenseOutcome = outcome)
+            }
+            refreshDiagnostics()
+        }
+    }
+
+    /** Show the Credential Manager one-tap account picker. */
+    fun runInteractivePicker(activity: Activity) {
+        viewModelScope.launch {
+            val outcome = repository.resolveTesterLicenseViaCredentialManager(activity)
             _uiState.value = _uiState.value.copy(testerLicenseOutcome = outcome)
             refreshDiagnostics()
         }
     }
 
-    /** Manual email-entry fallback when Sign-In is unavailable / the user declines. */
+    /** Manual email-entry fallback (e.g. user prefers not to use Credential Manager). */
     fun applyTesterLicenseManually(email: String) {
         viewModelScope.launch {
             val outcome = repository.applyTesterLicense(email)

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallViewModel.kt
@@ -3,12 +3,15 @@
 package com.hereliesaz.cuedetat.ui.composables.paywall
 
 import android.app.Activity
+import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hereliesaz.cuedetat.billing.BasePlanId
+import com.hereliesaz.cuedetat.billing.EntitlementDiagnostics
 import com.hereliesaz.cuedetat.billing.EntitlementRepository
 import com.hereliesaz.cuedetat.billing.PaywallTrigger
 import com.hereliesaz.cuedetat.billing.ProductDetailsState
+import com.hereliesaz.cuedetat.billing.TesterLicenseResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -51,6 +54,7 @@ class PaywallViewModel @Inject constructor(
                 }
             }
         }
+        refreshDiagnostics()
     }
 
     fun setTrigger(trigger: PaywallTrigger) {
@@ -69,7 +73,44 @@ class PaywallViewModel @Inject constructor(
     }
 
     fun restore() {
-        viewModelScope.launch { runCatching { repository.restorePurchases() } }
+        viewModelScope.launch {
+            runCatching { repository.restorePurchases() }
+            refreshDiagnostics()
+        }
+    }
+
+    /** Build the Google Sign-In intent the UI should launch. Null = not available. */
+    fun googleSignInIntent(): Intent? = repository.googleSignInIntent()
+
+    /** Consume the result of the Sign-In flow and attempt the allowlist match. */
+    fun applyTesterLicenseFromSignInResult(data: Intent?) {
+        viewModelScope.launch {
+            val outcome = repository.applyTesterLicenseFromSignInResult(data)
+            _uiState.value = _uiState.value.copy(testerLicenseOutcome = outcome)
+            refreshDiagnostics()
+        }
+    }
+
+    /** Manual email-entry fallback when Sign-In is unavailable / the user declines. */
+    fun applyTesterLicenseManually(email: String) {
+        viewModelScope.launch {
+            val outcome = repository.applyTesterLicense(email)
+            _uiState.value = _uiState.value.copy(testerLicenseOutcome = outcome)
+            refreshDiagnostics()
+        }
+    }
+
+    fun clearTesterLicenseOutcome() {
+        _uiState.value = _uiState.value.copy(testerLicenseOutcome = null)
+    }
+
+    fun toggleDiagnostics() {
+        _uiState.value = _uiState.value.copy(showDiagnostics = !_uiState.value.showDiagnostics)
+        refreshDiagnostics()
+    }
+
+    private fun refreshDiagnostics() {
+        _uiState.value = _uiState.value.copy(diagnostics = repository.diagnostics())
     }
 
     sealed class PurchaseFlowEvent {
@@ -80,5 +121,8 @@ class PaywallViewModel @Inject constructor(
 
 data class PaywallUiState(
     val productDetails: ProductDetailsState = ProductDetailsState.Loading,
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    val testerLicenseOutcome: TesterLicenseResult? = null,
+    val diagnostics: EntitlementDiagnostics = EntitlementDiagnostics(emptyList(), "not loaded", false),
+    val showDiagnostics: Boolean = false,
 )

--- a/app/src/play/java/com/hereliesaz/cuedetat/billing/BillingClientWrapper.kt
+++ b/app/src/play/java/com/hereliesaz/cuedetat/billing/BillingClientWrapper.kt
@@ -56,11 +56,29 @@ class BillingClientWrapper @Inject constructor(
             TAG,
             "purchasesListener responseCode=${result.responseCode} debug='${result.debugMessage}' size=${purchases?.size ?: 0}"
         )
+        purchases?.forEach { purchase ->
+            // Log each item so a tester can see in logcat exactly what
+            // products+states Play just reported. The repository will also
+            // record this into its rolling diagnostic buffer.
+            Log.i(
+                TAG,
+                "purchase products=${purchase.products} state=${purchase.purchaseState} " +
+                        "ack=${purchase.isAcknowledged} autoRenew=${purchase.isAutoRenewing}"
+            )
+        }
         if (result.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
             _purchaseUpdates.tryEmit(purchases)
+        } else if (result.responseCode != BillingClient.BillingResponseCode.USER_CANCELED) {
+            // USER_CANCELED is benign — the user backed out of the sheet.
+            // Anything else is a real problem and the user is otherwise
+            // staring at a "nothing happened" paywall. Warn so it is visible
+            // in logcat without needing to dig.
+            Log.w(
+                TAG,
+                "purchase did not result in OK; the user probably saw a failed purchase. " +
+                        "responseCode=${result.responseCode} debug='${result.debugMessage}'"
+            )
         }
-        // Other response codes are surfaced by the suspend functions that
-        // initiate flows; this listener only forwards successful updates.
     }
 
     private val client: BillingClient = BillingClient.newBuilder(context)

--- a/app/src/play/java/com/hereliesaz/cuedetat/billing/GoogleAccountResolver.kt
+++ b/app/src/play/java/com/hereliesaz/cuedetat/billing/GoogleAccountResolver.kt
@@ -1,0 +1,124 @@
+// FILE: app/src/play/java/com/hereliesaz/cuedetat/billing/GoogleAccountResolver.kt
+
+package com.hereliesaz.cuedetat.billing
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.common.api.ApiException
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Resolves the device's Google account email so we can match it against the
+ * tester-license allowlist. Two access patterns:
+ *
+ *  - [resolveSilently] — non-interactive. Returns an email if the user is
+ *    already signed in with our app's GoogleSignInClient; null otherwise.
+ *  - [signInIntent] / [parseSignInResult] — interactive picker. Caller
+ *    launches the intent, gets the activity result, and passes it back to
+ *    parseSignInResult to extract the email.
+ *
+ * The basic GoogleSignInOptions.DEFAULT_SIGN_IN configuration requests
+ * profile + ID, which includes the email address, and does not require any
+ * web/OAuth client ID to be configured in Google Cloud Console. This keeps
+ * the wiring minimal: as long as the device has a Google account and Play
+ * Services available, the silent path returns an email after the first
+ * interactive sign-in.
+ */
+@Singleton
+class GoogleAccountResolver @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+
+    private val signInOptions: GoogleSignInOptions by lazy {
+        GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestEmail()
+            .build()
+    }
+
+    private val client: GoogleSignInClient by lazy {
+        GoogleSignIn.getClient(context, signInOptions)
+    }
+
+    /**
+     * Returns the last cached signed-in account's email without showing UI.
+     * Null if the user has never signed in (with our client) on this device.
+     */
+    fun resolveSilently(): String? {
+        val account = GoogleSignIn.getLastSignedInAccount(context)
+        val email = account?.email
+        if (email.isNullOrBlank()) {
+            Log.i(TAG, "resolveSilently: no cached account")
+            return null
+        }
+        Log.i(TAG, "resolveSilently: cached account hash=${TestLicenseAllowlist.sha256Hex(email.lowercase())}")
+        return email
+    }
+
+    /**
+     * Attempts silent sign-in. Unlike [resolveSilently], this re-validates the
+     * cached credentials with Play Services and refreshes the token. Returns
+     * the email on success.
+     */
+    suspend fun resolveSilentlyRefresh(): String? {
+        return try {
+            val account: GoogleSignInAccount = client.silentSignIn().await()
+            val email = account.email
+            if (email.isNullOrBlank()) {
+                Log.i(TAG, "silentSignIn: account present but no email scope granted")
+                null
+            } else {
+                Log.i(TAG, "silentSignIn: hash=${TestLicenseAllowlist.sha256Hex(email.lowercase())}")
+                email
+            }
+        } catch (e: ApiException) {
+            Log.i(TAG, "silentSignIn failed (statusCode=${e.statusCode}); caller should launch interactive picker", e)
+            null
+        } catch (e: Exception) {
+            Log.w(TAG, "silentSignIn threw", e)
+            null
+        }
+    }
+
+    /** Intent to launch via Activity.startActivityForResult to show the picker. */
+    fun signInIntent(): Intent = client.signInIntent
+
+    /** Extracts the email from a sign-in activity result. Null on failure. */
+    fun parseSignInResult(data: Intent?): String? {
+        if (data == null) return null
+        return try {
+            val task = GoogleSignIn.getSignedInAccountFromIntent(data)
+            val account = task.getResult(ApiException::class.java)
+            val email = account?.email
+            if (email.isNullOrBlank()) {
+                Log.i(TAG, "parseSignInResult: account present but no email scope granted")
+                null
+            } else {
+                Log.i(TAG, "parseSignInResult: hash=${TestLicenseAllowlist.sha256Hex(email.lowercase())}")
+                email
+            }
+        } catch (e: ApiException) {
+            Log.w(TAG, "parseSignInResult: ApiException statusCode=${e.statusCode}", e)
+            null
+        } catch (e: Exception) {
+            Log.w(TAG, "parseSignInResult threw", e)
+            null
+        }
+    }
+
+    /** Forgets the cached sign-in so the next interactive call re-prompts. */
+    suspend fun signOut() {
+        runCatching { client.signOut().await() }
+    }
+
+    companion object {
+        private const val TAG = "TesterLicense"
+    }
+}

--- a/app/src/play/java/com/hereliesaz/cuedetat/billing/GoogleAccountResolver.kt
+++ b/app/src/play/java/com/hereliesaz/cuedetat/billing/GoogleAccountResolver.kt
@@ -2,120 +2,128 @@
 
 package com.hereliesaz.cuedetat.billing
 
+import android.app.Activity
 import android.content.Context
-import android.content.Intent
 import android.util.Log
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.auth.api.signin.GoogleSignInAccount
-import com.google.android.gms.auth.api.signin.GoogleSignInClient
-import com.google.android.gms.auth.api.signin.GoogleSignInOptions
-import com.google.android.gms.common.api.ApiException
+import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.NoCredentialException
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
+import com.hereliesaz.cuedetat.BuildConfig
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Resolves the device's Google account email so we can match it against the
- * tester-license allowlist. Two access patterns:
+ * Resolves the device's Google account email via Credential Manager + the
+ * Google ID provider, so we can match it against the tester-license
+ * allowlist. Two access patterns:
  *
- *  - [resolveSilently] — non-interactive. Returns an email if the user is
- *    already signed in with our app's GoogleSignInClient; null otherwise.
- *  - [signInIntent] / [parseSignInResult] — interactive picker. Caller
- *    launches the intent, gets the activity result, and passes it back to
- *    parseSignInResult to extract the email.
+ *  - [resolveAuthorizedSilently] — non-interactive. Returns the email if
+ *    the user has previously authorized our app for this account; null
+ *    otherwise. Safe to call on cold start.
+ *  - [resolveInteractive] — shows the one-tap account picker so a tester
+ *    can pick their account if they haven't authorized us yet.
  *
- * The basic GoogleSignInOptions.DEFAULT_SIGN_IN configuration requests
- * profile + ID, which includes the email address, and does not require any
- * web/OAuth client ID to be configured in Google Cloud Console. This keeps
- * the wiring minimal: as long as the device has a Google account and Play
- * Services available, the silent path returns an email after the first
- * interactive sign-in.
+ * Both require [BuildConfig.GOOGLE_OAUTH_WEB_CLIENT_ID] to be set. When
+ * the build was assembled without it (e.g. local dev without
+ * `GOOGLE_OAUTH_WEB_CLIENT_ID` in local.properties), the methods short-
+ * circuit to null and log a warning, rather than crashing.
+ *
+ * The returned email is the `id` field of [GoogleIdTokenCredential]. We
+ * don't verify the token signature on-device: this email is only used as
+ * input to a sha256 hash compared against a build-baked allowlist. It is
+ * never sent off-device, used as an authn principal, or trusted for
+ * anything else.
  */
 @Singleton
 class GoogleAccountResolver @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
 
-    private val signInOptions: GoogleSignInOptions by lazy {
-        GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestEmail()
-            .build()
+    private val credentialManager: CredentialManager by lazy {
+        CredentialManager.create(context)
     }
 
-    private val client: GoogleSignInClient by lazy {
-        GoogleSignIn.getClient(context, signInOptions)
-    }
+    private val webClientId: String? = BuildConfig.GOOGLE_OAUTH_WEB_CLIENT_ID.takeIf { it.isNotBlank() }
+
+    val isConfigured: Boolean get() = webClientId != null
 
     /**
-     * Returns the last cached signed-in account's email without showing UI.
-     * Null if the user has never signed in (with our client) on this device.
+     * Silent (no UI) attempt. Only returns an email if the user has
+     * previously authorized this app for one of their Google accounts.
      */
-    fun resolveSilently(): String? {
-        val account = GoogleSignIn.getLastSignedInAccount(context)
-        val email = account?.email
-        if (email.isNullOrBlank()) {
-            Log.i(TAG, "resolveSilently: no cached account")
+    suspend fun resolveAuthorizedSilently(activity: Activity): String? {
+        val clientId = webClientId ?: run {
+            Log.w(TAG, "resolveAuthorizedSilently: no Web OAuth client id baked in; skipping")
             return null
         }
-        Log.i(TAG, "resolveSilently: cached account hash=${TestLicenseAllowlist.sha256Hex(email.lowercase())}")
-        return email
+        return resolve(activity, clientId, authorizedOnly = true)
     }
 
     /**
-     * Attempts silent sign-in. Unlike [resolveSilently], this re-validates the
-     * cached credentials with Play Services and refreshes the token. Returns
-     * the email on success.
+     * Interactive picker. Shows the one-tap account chooser, returns the
+     * email of the picked account on success.
      */
-    suspend fun resolveSilentlyRefresh(): String? {
-        return try {
-            val account: GoogleSignInAccount = client.silentSignIn().await()
-            val email = account.email
-            if (email.isNullOrBlank()) {
-                Log.i(TAG, "silentSignIn: account present but no email scope granted")
-                null
-            } else {
-                Log.i(TAG, "silentSignIn: hash=${TestLicenseAllowlist.sha256Hex(email.lowercase())}")
-                email
-            }
-        } catch (e: ApiException) {
-            Log.i(TAG, "silentSignIn failed (statusCode=${e.statusCode}); caller should launch interactive picker", e)
-            null
-        } catch (e: Exception) {
-            Log.w(TAG, "silentSignIn threw", e)
-            null
+    suspend fun resolveInteractive(activity: Activity): String? {
+        val clientId = webClientId ?: run {
+            Log.w(TAG, "resolveInteractive: no Web OAuth client id baked in; cannot show picker")
+            return null
         }
+        return resolve(activity, clientId, authorizedOnly = false)
     }
 
-    /** Intent to launch via Activity.startActivityForResult to show the picker. */
-    fun signInIntent(): Intent = client.signInIntent
-
-    /** Extracts the email from a sign-in activity result. Null on failure. */
-    fun parseSignInResult(data: Intent?): String? {
-        if (data == null) return null
+    private suspend fun resolve(
+        activity: Activity,
+        clientId: String,
+        authorizedOnly: Boolean,
+    ): String? {
+        val option = GetGoogleIdOption.Builder()
+            .setServerClientId(clientId)
+            .setFilterByAuthorizedAccounts(authorizedOnly)
+            .setAutoSelectEnabled(authorizedOnly)
+            .build()
+        val request = GetCredentialRequest.Builder()
+            .addCredentialOption(option)
+            .build()
         return try {
-            val task = GoogleSignIn.getSignedInAccountFromIntent(data)
-            val account = task.getResult(ApiException::class.java)
-            val email = account?.email
-            if (email.isNullOrBlank()) {
-                Log.i(TAG, "parseSignInResult: account present but no email scope granted")
-                null
+            val response = credentialManager.getCredential(activity, request)
+            val credential = response.credential
+            if (credential is CustomCredential &&
+                credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
+            ) {
+                val gid = GoogleIdTokenCredential.createFrom(credential.data)
+                val email = gid.id
+                if (email.isBlank()) {
+                    Log.w(TAG, "resolve: GoogleIdTokenCredential.id was blank")
+                    null
+                } else {
+                    Log.i(TAG, "resolve: hash=${TestLicenseAllowlist.sha256Hex(email.lowercase())}")
+                    email
+                }
             } else {
-                Log.i(TAG, "parseSignInResult: hash=${TestLicenseAllowlist.sha256Hex(email.lowercase())}")
-                email
+                Log.w(TAG, "resolve: unexpected credential type=${credential::class.java.simpleName}")
+                null
             }
-        } catch (e: ApiException) {
-            Log.w(TAG, "parseSignInResult: ApiException statusCode=${e.statusCode}", e)
+        } catch (e: NoCredentialException) {
+            // Silent path: user has no authorized account. Non-fatal; the
+            // paywall will offer an interactive picker.
+            Log.i(TAG, "resolve(authorizedOnly=$authorizedOnly): no authorized account; ${e.message}")
+            null
+        } catch (e: GetCredentialException) {
+            Log.w(TAG, "resolve(authorizedOnly=$authorizedOnly): GetCredentialException type=${e.type}", e)
+            null
+        } catch (e: GoogleIdTokenParsingException) {
+            Log.w(TAG, "resolve: parsing exception", e)
             null
         } catch (e: Exception) {
-            Log.w(TAG, "parseSignInResult threw", e)
+            Log.w(TAG, "resolve(authorizedOnly=$authorizedOnly): unexpected", e)
             null
         }
-    }
-
-    /** Forgets the cached sign-in so the next interactive call re-prompts. */
-    suspend fun signOut() {
-        runCatching { client.signOut().await() }
     }
 
     companion object {

--- a/app/src/play/java/com/hereliesaz/cuedetat/billing/PlayBillingEntitlementRepository.kt
+++ b/app/src/play/java/com/hereliesaz/cuedetat/billing/PlayBillingEntitlementRepository.kt
@@ -44,6 +44,7 @@ class PlayBillingEntitlementRepository @Inject constructor(
     private val testLicenseAllowlist: TestLicenseAllowlist,
     private val testLicenseStore: TestLicenseStore,
     private val integrityRepository: IntegrityRepository,
+    private val googleAccountResolver: GoogleAccountResolver,
 ) : EntitlementRepository {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -59,6 +60,14 @@ class PlayBillingEntitlementRepository @Inject constructor(
     /** Whether the last integrity check succeeded. */
     private var isDeviceGenuine = true
 
+    /** Rolling log of recent purchase snapshot lines for the in-app diagnostic. */
+    private val recentPurchaseLog = ArrayDeque<String>()
+    private val recentPurchaseLogMaxSize = 30
+
+    /** Human-readable summary of the last refresh outcome for the diagnostic. */
+    @Volatile
+    private var lastRefreshOutcome: String = "not yet attempted"
+
     private val _entitlement = MutableStateFlow(Entitlement.NONE)
     override val entitlement: StateFlow<Entitlement> = _entitlement.asStateFlow()
 
@@ -69,16 +78,21 @@ class PlayBillingEntitlementRepository @Inject constructor(
             // 1. Load cache so the first emission is correct for returning users.
             val cached = runCatching { cacheStore.read() }.getOrDefault(Entitlement.NONE)
             playEntitlement.value = applyOfflineCap(cached, System.currentTimeMillis())
+            Log.i(TAG, "init: cached entitlement active=${cached.active} source=${cached.source}")
             republish()
 
             // 2. Restore any previously-verified tester license. If the
             //    allowlist no longer contains the stored hash (group membership
             //    changed between builds) we drop it on the floor and clear it.
             testLicenseStore.verifiedHash.collect { hash ->
-                verifiedTesterHash = hash?.takeIf(testLicenseAllowlist::containsHash)
-                if (hash != null && verifiedTesterHash == null) {
+                val accepted = hash?.takeIf(testLicenseAllowlist::containsHash)
+                if (hash != null && accepted == null) {
+                    Log.i(TAG, "stored tester hash no longer on allowlist; clearing")
                     runCatching { testLicenseStore.clear() }
+                } else if (accepted != null) {
+                    Log.i(TAG, "tester license restored from store")
                 }
+                verifiedTesterHash = accepted
                 republish()
             }
         }
@@ -97,14 +111,21 @@ class PlayBillingEntitlementRepository @Inject constructor(
             // 4. Refresh from Play in the background.
             refresh()
 
-            // 4. React to purchase updates.
+            // 5. Attempt silent tester-license auto-resolution once we know
+            //    nothing is cached. The user is most likely to be a tester
+            //    here, and we don't want them to have to discover the manual
+            //    flow. Quietly noop if there is no cached account.
+            tryAutoResolveTesterLicense()
+
+            // 6. React to purchase updates.
             billingClient.purchaseUpdates.collect { purchases ->
+                Log.i(TAG, "purchaseUpdates: ${purchases.size} purchases received")
                 purchases.forEach { runCatching { billingClient.acknowledgeIfNeeded(it) } }
                 refresh()
             }
         }
 
-        // 4. Re-verify on every process foreground. Recovers from a transient
+        // 7. Re-verify on every process foreground. Recovers from a transient
         //    failure during the cold-start refresh and from races where Play
         //    Store registers a purchase moments after our initial query.
         scope.launch {
@@ -122,17 +143,20 @@ class PlayBillingEntitlementRepository @Inject constructor(
 
     override suspend fun launchPurchase(activity: Activity, basePlan: BasePlanId) {
         val productDetails = billingClient.queryExpertProductDetails() ?: run {
+            Log.w(TAG, "launchPurchase: product details unavailable for ${BillingProductIds.PRODUCT_ID_EXPERT}")
             _productDetails.tryEmit(ProductDetailsState.Error(-1, "Product details unavailable"))
             return
         }
         val offer = productDetails.subscriptionOfferDetails
             ?.firstOrNull { it.basePlanId == basePlan.tag }
             ?: run {
+                Log.w(TAG, "launchPurchase: base plan '${basePlan.tag}' not configured in Play Console")
                 _productDetails.tryEmit(
                     ProductDetailsState.Error(-1, "Base plan ${basePlan.tag} not configured")
                 )
                 return
             }
+        Log.i(TAG, "launchPurchase: basePlan=${basePlan.tag} productId=${productDetails.productId}")
         billingClient.launchBillingFlow(activity, productDetails, offer.offerToken)
     }
 
@@ -143,42 +167,123 @@ class PlayBillingEntitlementRepository @Inject constructor(
                 // Transient failure: keep the previous entitlement (subject to
                 // the 14-day offline cap) and do NOT overwrite the cache.
                 Log.w(TAG, "queryActiveSubscriptions failed; preserving cached entitlement", it)
+                lastRefreshOutcome = "queryActiveSubscriptions failed: ${it.message ?: it::class.java.simpleName}"
                 playEntitlement.value = applyOfflineCap(playEntitlement.value, now)
                 republish()
                 return
             }
         val snapshots = purchases.flatMap { it.toSnapshots() }
         snapshots.forEach {
-            Log.i(TAG, "snapshot productId=${it.productId} state=${it.purchaseState} ack=${it.isAcknowledged}")
+            val line = "snapshot productId=${it.productId} state=${it.purchaseState} ack=${it.isAcknowledged} autoRenew=${it.isAutoRenewing}"
+            Log.i(TAG, line)
+            recordPurchaseSnapshot(line)
+        }
+        if (snapshots.isEmpty()) {
+            val line = "snapshot none — Play returned 0 active subscriptions"
+            Log.i(TAG, line)
+            recordPurchaseSnapshot(line)
         }
         val mapped = PurchaseToEntitlementMapper.map(snapshots, now)
-        Log.i(TAG, "refresh result active=${mapped.active} source=${mapped.source}")
+        val outcome = "active=${mapped.active} source=${mapped.source} productId=${mapped.productId ?: "n/a"} " +
+                "(expected productId=${BillingProductIds.PRODUCT_ID_EXPERT})"
+        Log.i(TAG, "refresh result $outcome")
+        lastRefreshOutcome = outcome
         playEntitlement.value = mapped
         runCatching { cacheStore.write(mapped) }
         republish()
     }
 
     /**
-     * Attempt to grant a tester license. Returns true if `email` matched the
-     * baked-in allowlist; the verified hash is persisted so future launches
-     * stay entitled without re-entry.
+     * Attempt to grant a tester license by hashing `email` and matching the
+     * baked-in allowlist. Public via [EntitlementRepository.applyTesterLicense]
+     * so the paywall can offer a manual fallback.
      */
     suspend fun tryApplyTesterLicense(email: String): Boolean {
         if (!testLicenseAllowlist.isAllowed(email)) return false
         val hash = TestLicenseAllowlist.sha256Hex(email.trim().lowercase())
         testLicenseStore.setVerifiedHash(hash)
-        // The store collector will pick up the change and call republish(),
-        // but apply immediately so callers see the updated state on return.
         verifiedTesterHash = hash
         republish()
+        Log.i(TAG, "tryApplyTesterLicense: granted (hash=$hash)")
         return true
     }
 
-    /** Revoke the tester license stored on this device. */
-    suspend fun clearTesterLicense() {
+    override suspend fun applyTesterLicense(email: String): TesterLicenseResult {
+        if (email.trim().isEmpty() || !email.contains('@')) {
+            Log.i(TAG, "applyTesterLicense: invalid email rejected")
+            return TesterLicenseResult.InvalidEmail
+        }
+        if (!testLicenseAllowlist.isConfigured) {
+            Log.i(TAG, "applyTesterLicense: allowlist not configured in this build")
+            return TesterLicenseResult.AllowlistEmpty
+        }
+        return if (tryApplyTesterLicense(email)) {
+            TesterLicenseResult.Granted
+        } else {
+            Log.i(TAG, "applyTesterLicense: hash not on allowlist")
+            TesterLicenseResult.NotOnAllowlist
+        }
+    }
+
+    override suspend fun clearTesterLicense() {
         testLicenseStore.clear()
         verifiedTesterHash = null
         republish()
+        Log.i(TAG, "clearTesterLicense: revoked")
+    }
+
+    override fun diagnostics(): EntitlementDiagnostics {
+        val snapshots = synchronized(recentPurchaseLog) { recentPurchaseLog.toList() }
+        return EntitlementDiagnostics(
+            recentPurchaseSnapshots = snapshots,
+            lastRefreshOutcome = lastRefreshOutcome,
+            testerAllowlistConfigured = testLicenseAllowlist.isConfigured,
+        )
+    }
+
+    override fun googleSignInIntent(): android.content.Intent? =
+        runCatching { googleAccountResolver.signInIntent() }.getOrNull()
+
+    override suspend fun applyTesterLicenseFromSignInResult(
+        data: android.content.Intent?
+    ): TesterLicenseResult {
+        val email = googleAccountResolver.parseSignInResult(data)
+        if (email == null) {
+            Log.i(TAG, "applyTesterLicenseFromSignInResult: no email in result")
+            return TesterLicenseResult.InvalidEmail
+        }
+        return applyTesterLicense(email)
+    }
+
+    /**
+     * Best-effort silent tester-license resolution. Reads the device's
+     * cached Google account email (no UI) and tries the allowlist. If there
+     * is no cached account, returns silently — the paywall will show a
+     * "Sign in with Google" button so the user can opt in interactively.
+     */
+    private suspend fun tryAutoResolveTesterLicense() {
+        if (verifiedTesterHash != null) return
+        if (!testLicenseAllowlist.isConfigured) {
+            Log.i(TAG, "auto tester resolve: allowlist not configured; skipping")
+            return
+        }
+        val cached = googleAccountResolver.resolveSilently()
+        val email = cached ?: googleAccountResolver.resolveSilentlyRefresh()
+        if (email == null) {
+            Log.i(TAG, "auto tester resolve: no cached Google account on device")
+            return
+        }
+        val granted = tryApplyTesterLicense(email)
+        Log.i(TAG, "auto tester resolve: granted=$granted")
+    }
+
+    private fun recordPurchaseSnapshot(line: String) {
+        synchronized(recentPurchaseLog) {
+            recentPurchaseLog.addLast("${System.currentTimeMillis()}: $line")
+            while (recentPurchaseLog.size > recentPurchaseLogMaxSize) {
+                recentPurchaseLog.removeFirst()
+            }
+        }
     }
 
     /**
@@ -211,6 +316,7 @@ class PlayBillingEntitlementRepository @Inject constructor(
             val details = runCatching { billingClient.queryExpertProductDetails() }
                 .getOrNull()
             if (details == null) {
+                Log.w(TAG, "productDetails: query returned null")
                 _productDetails.tryEmit(
                     ProductDetailsState.Error(-1, "Product details query failed")
                 )
@@ -220,6 +326,7 @@ class PlayBillingEntitlementRepository @Inject constructor(
             val yearly = details.findFormattedPrice(BasePlanId.YEARLY)
             val trialDays = details.findTrialDays()
             if (monthly == null || yearly == null) {
+                Log.w(TAG, "productDetails: missing base plan price (monthly=$monthly yearly=$yearly)")
                 _productDetails.tryEmit(
                     ProductDetailsState.Error(-1, "Configured base plans missing")
                 )

--- a/app/src/play/java/com/hereliesaz/cuedetat/billing/PlayBillingEntitlementRepository.kt
+++ b/app/src/play/java/com/hereliesaz/cuedetat/billing/PlayBillingEntitlementRepository.kt
@@ -111,13 +111,12 @@ class PlayBillingEntitlementRepository @Inject constructor(
             // 4. Refresh from Play in the background.
             refresh()
 
-            // 5. Attempt silent tester-license auto-resolution once we know
-            //    nothing is cached. The user is most likely to be a tester
-            //    here, and we don't want them to have to discover the manual
-            //    flow. Quietly noop if there is no cached account.
-            tryAutoResolveTesterLicense()
+            // (Silent tester-license auto-resolve is now Activity-bound and
+            //  triggered by MainActivity once the first activity is alive.
+            //  Credential Manager requires an Activity context; see
+            //  autoResolveOnNextResume.)
 
-            // 6. React to purchase updates.
+            // 5. React to purchase updates.
             billingClient.purchaseUpdates.collect { purchases ->
                 Log.i(TAG, "purchaseUpdates: ${purchases.size} purchases received")
                 purchases.forEach { runCatching { billingClient.acknowledgeIfNeeded(it) } }
@@ -241,40 +240,37 @@ class PlayBillingEntitlementRepository @Inject constructor(
         )
     }
 
-    override fun googleSignInIntent(): android.content.Intent? =
-        runCatching { googleAccountResolver.signInIntent() }.getOrNull()
+    override val isCredentialManagerAvailable: Boolean
+        get() = googleAccountResolver.isConfigured && testLicenseAllowlist.isConfigured
 
-    override suspend fun applyTesterLicenseFromSignInResult(
-        data: android.content.Intent?
+    override suspend fun resolveTesterLicenseViaCredentialManager(
+        activity: android.app.Activity,
     ): TesterLicenseResult {
-        val email = googleAccountResolver.parseSignInResult(data)
+        if (!testLicenseAllowlist.isConfigured) {
+            Log.i(TAG, "resolveTesterLicenseViaCredentialManager: allowlist not configured")
+            return TesterLicenseResult.AllowlistEmpty
+        }
+        if (!googleAccountResolver.isConfigured) {
+            Log.i(TAG, "resolveTesterLicenseViaCredentialManager: Credential Manager not configured")
+            return TesterLicenseResult.NotApplicable
+        }
+        val email = googleAccountResolver.resolveInteractive(activity)
         if (email == null) {
-            Log.i(TAG, "applyTesterLicenseFromSignInResult: no email in result")
+            Log.i(TAG, "resolveTesterLicenseViaCredentialManager: no email returned from picker")
             return TesterLicenseResult.InvalidEmail
         }
         return applyTesterLicense(email)
     }
 
-    /**
-     * Best-effort silent tester-license resolution. Reads the device's
-     * cached Google account email (no UI) and tries the allowlist. If there
-     * is no cached account, returns silently — the paywall will show a
-     * "Sign in with Google" button so the user can opt in interactively.
-     */
-    private suspend fun tryAutoResolveTesterLicense() {
-        if (verifiedTesterHash != null) return
-        if (!testLicenseAllowlist.isConfigured) {
-            Log.i(TAG, "auto tester resolve: allowlist not configured; skipping")
-            return
-        }
-        val cached = googleAccountResolver.resolveSilently()
-        val email = cached ?: googleAccountResolver.resolveSilentlyRefresh()
-        if (email == null) {
-            Log.i(TAG, "auto tester resolve: no cached Google account on device")
-            return
-        }
-        val granted = tryApplyTesterLicense(email)
-        Log.i(TAG, "auto tester resolve: granted=$granted")
+    override suspend fun silentlyResolveTesterLicense(
+        activity: android.app.Activity,
+    ): TesterLicenseResult {
+        if (verifiedTesterHash != null) return TesterLicenseResult.Granted
+        if (!testLicenseAllowlist.isConfigured) return TesterLicenseResult.AllowlistEmpty
+        if (!googleAccountResolver.isConfigured) return TesterLicenseResult.NotApplicable
+        val email = googleAccountResolver.resolveAuthorizedSilently(activity)
+            ?: return TesterLicenseResult.InvalidEmail
+        return applyTesterLicense(email)
     }
 
     private fun recordPurchaseSnapshot(line: String) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,6 +89,7 @@ guavaVulnerability = "33.6.0-android"
 netty = "4.1.132.Final"
 androidx-billing = "8.3.0"
 play-integrity = "1.6.0"
+playServicesAuth = "21.4.0"
 
 
 [libraries]
@@ -102,6 +103,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-billing-ktx = { group = "com.android.billingclient", name = "billing-ktx", version.ref = "androidx-billing" }
 play-integrity = { group = "com.google.android.play", name = "integrity", version.ref = "play-integrity" }
+play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "playServicesAuth" }
 androidx-datastore-preferences-rxjava2 = { module = "androidx.datastore:datastore-preferences-rxjava2", version.ref = "datastorePreferences" }
 androidx-datastore-preferences-rxjava3 = { module = "androidx.datastore:datastore-preferences-rxjava3", version.ref = "datastorePreferences" }
 androidx-glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glanceAppwidget" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,7 +89,8 @@ guavaVulnerability = "33.6.0-android"
 netty = "4.1.132.Final"
 androidx-billing = "8.3.0"
 play-integrity = "1.6.0"
-playServicesAuth = "21.4.0"
+androidxCredentials = "1.5.0"
+googleId = "1.1.1"
 
 
 [libraries]
@@ -103,7 +104,9 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-billing-ktx = { group = "com.android.billingclient", name = "billing-ktx", version.ref = "androidx-billing" }
 play-integrity = { group = "com.google.android.play", name = "integrity", version.ref = "play-integrity" }
-play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "playServicesAuth" }
+androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "androidxCredentials" }
+androidx-credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "androidxCredentials" }
+google-id = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleId" }
 androidx-datastore-preferences-rxjava2 = { module = "androidx.datastore:datastore-preferences-rxjava2", version.ref = "datastorePreferences" }
 androidx-datastore-preferences-rxjava3 = { module = "androidx.datastore:datastore-preferences-rxjava3", version.ref = "datastorePreferences" }
 androidx-glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glanceAppwidget" }


### PR DESCRIPTION
## Summary

Two threads woven together: (1) hook the existing tester-license allowlist up to a real entry point so a tester actually gets entitled, and (2) give the paywall a diagnostic surface so a real-purchase failure stops looking like "nothing happened."

The infrastructure was already there:
- `fetch-tester-emails.mjs` + `FetchTesterEmailsTask` scrape your tester Google Group at build time and bake `tester_emails.txt` (SHA-256 hashes) into the `playRelease` APK.
- `TestLicenseAllowlist.isAllowed(email)` matches an incoming email against the baked list.
- `PlayBillingEntitlementRepository.tryApplyTesterLicense(email)` grants the entitlement.

…but nothing ever called `tryApplyTesterLicense`, so the allowlist was effectively dead.

## What this changes

**Auto-detect the Google Play account email**

- New `GoogleAccountResolver` (play flavor) uses `play-services-auth` to read the device's signed-in Google account email. Two access patterns:
  - silent (`resolveSilently` / `silentSignIn`) — returns cached account without UI
  - interactive (`signInIntent` + activity-result callback)
- `PlayBillingEntitlementRepository.tryAutoResolveTesterLicense` runs once on startup. If the allowlist is configured and the device has a cached Google account, it hashes the email and applies the tester license with no UI. Result is persisted, so subsequent launches just see "already a tester."

**Manual fallbacks in the paywall**

- "Check via Google Sign-In" button (interactive picker) — for users who haven't signed in with this app yet.
- Manual email-entry fallback — useful when Sign-In is declined or unavailable.
- Outcome message renders inline (`Granted` / `NotOnAllowlist` / `AllowlistEmpty` / `InvalidEmail`).

**Diagnostic surface (debugging "my purchase didn't unlock")**

- Expandable "billing diagnostics" panel in the paywall shows:
  - Whether the allowlist is baked into this APK
  - Last `refresh()` outcome including the **expected** productId, so a Play Console / APK product-ID mismatch is visible from the device.
  - A rolling buffer of the last ~30 purchase snapshots Play returned (productId / state / ack / autoRenew).
- `PlayBillingEntitlementRepository.refresh` and `BillingClientWrapper.purchasesListener` now log every per-purchase line via `Log.i(TAG, …)` so the same data is grep-able in logcat.
- Non-OK billing response codes (other than `USER_CANCELED`) now emit a `Log.w` — a failed-purchase flow no longer looks indistinguishable from a successful one in logs.

**Interface contract**

- `EntitlementRepository` gains `applyTesterLicense(email)`, `clearTesterLicense()`, `googleSignInIntent()`, `applyTesterLicenseFromSignInResult(intent)`, and `diagnostics()`. All have safe default implementations so the FOSS impl doesn't need to change.

## Dependencies

- Adds `com.google.android.gms:play-services-auth` to the **play flavor only**. FOSS APK is unaffected.

## Test plan

- [ ] Build a `playRelease` APK with `GG_LINK`/`GG_SESSION` set; install on a device whose Play account is in the tester group; confirm Expert is unlocked on first launch.
- [ ] Open the paywall on a non-tester account; confirm "Check via Google Sign-In" shows the account picker, picks an account, and reports `NotOnAllowlist`.
- [ ] Use the manual email field with a non-allowlist email; confirm `NotOnAllowlist`.
- [ ] Use the manual email field with a known tester email; confirm `Granted` and that Expert mode unlocks.
- [ ] Make a real test subscription purchase in Closed Testing; if it doesn't unlock, open the paywall's billing diagnostics and inspect the snapshot output (this is the primary debugging tool now).
- [ ] FOSS flavor still builds and runs (allowlist call should fall through to `NotApplicable`).

## Open questions

- Closed-testing real-purchase debugging still depends on having a device to test against — this PR makes the failure observable but doesn't *fix* a missing/mismatched Play Console product. Once you can see the diagnostic output, that will tell us what's actually happening.

https://claude.ai/code/session_01RqmDFDMFcSoZ2CZJPtDQMY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqmDFDMFcSoZ2CZJPtDQMY)_

## Summary by Sourcery

Integrate Google account–based tester license resolution and expose richer billing diagnostics in the paywall and a new billing debug dialog.

New Features:
- Add Google account–based tester license flows, including silent auto-resolution on startup and interactive account picker/manual email entry from the paywall.
- Introduce an in-app Billing & License debug dialog with entitlement state, tester license controls, and purchase snapshot diagnostics, accessible from the advanced options menu.

Enhancements:
- Extend EntitlementRepository with tester license operations, diagnostics accessors, and a capability flag used by UI layers.
- Augment PlayBillingEntitlementRepository with tester license handling, rolling purchase logs, and detailed refresh/purchase logging for easier troubleshooting.
- Enhance the paywall UI to show tester license status, diagnostics panel, and react to updated billing diagnostics.
- Improve BillingClientWrapper logging and error handling to surface non-OK billing response codes and per-purchase details in logs.

Build:
- Add Credential Manager and Google ID dependencies plus GOOGLE_OAUTH_WEB_CLIENT_ID build config for the play flavor only.