### PR TITLE
Fix: tutorials fire every mode open instead of just once

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/UserPreferencesRepository.kt
@@ -5,6 +5,7 @@ package com.hereliesaz.cuedetat.data
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -14,6 +15,7 @@ import com.hereliesaz.cuedetat.domain.CueDetatState
 import com.hereliesaz.cuedetat.view.state.TutorialHighlightElement
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import org.opencv.core.CvType
 import org.opencv.core.Mat
@@ -34,6 +36,48 @@ class UserPreferencesRepository @Inject constructor(
         val STATE_JSON = stringPreferencesKey("state_json")
         val CAMERA_MATRIX_JSON = stringPreferencesKey("camera_matrix_json")
         val DIST_COEFFS_JSON = stringPreferencesKey("dist_coeffs_json")
+
+        // Tutorial-seen flags are stored as dedicated keys (not embedded in
+        // STATE_JSON) so they survive the 2-second debounce on the main state
+        // save. The state save can be cancelled indefinitely by the high-rate
+        // FullOrientationChanged sensor events; these flags must reach disk
+        // the moment the user taps "Done", or the tutorial fires again on
+        // every fresh launch.
+        val HAS_SEEN_BEGINNER_TUTORIAL = booleanPreferencesKey("has_seen_beginner_tutorial")
+        val HAS_SEEN_DYNAMIC_BEGINNER_TUTORIAL = booleanPreferencesKey("has_seen_dynamic_beginner_tutorial")
+        val HAS_SEEN_EXPERT_TUTORIAL = booleanPreferencesKey("has_seen_expert_tutorial")
+    }
+
+    data class TutorialSeenFlags(
+        val beginner: Boolean,
+        val dynamicBeginner: Boolean,
+        val expert: Boolean,
+    )
+
+    suspend fun readTutorialSeenFlags(): TutorialSeenFlags {
+        val prefs = dataStore.data.first()
+        return TutorialSeenFlags(
+            beginner = prefs[PreferencesKeys.HAS_SEEN_BEGINNER_TUTORIAL] ?: false,
+            dynamicBeginner = prefs[PreferencesKeys.HAS_SEEN_DYNAMIC_BEGINNER_TUTORIAL] ?: false,
+            expert = prefs[PreferencesKeys.HAS_SEEN_EXPERT_TUTORIAL] ?: false,
+        )
+    }
+
+    /**
+     * Persists only the flags that are set to `true`. Designed to be called
+     * with the latest CueDetatState's seen flags whenever any of them flips.
+     * Idempotent — re-writing `true` for an already-true flag is harmless.
+     */
+    suspend fun setTutorialSeenFlags(
+        beginner: Boolean,
+        dynamicBeginner: Boolean,
+        expert: Boolean,
+    ) {
+        dataStore.edit { prefs ->
+            if (beginner) prefs[PreferencesKeys.HAS_SEEN_BEGINNER_TUTORIAL] = true
+            if (dynamicBeginner) prefs[PreferencesKeys.HAS_SEEN_DYNAMIC_BEGINNER_TUTORIAL] = true
+            if (expert) prefs[PreferencesKeys.HAS_SEEN_EXPERT_TUTORIAL] = true
+        }
     }
 
     val stateFlow: Flow<CueDetatState?> = dataStore.data

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
@@ -170,10 +170,19 @@ class MainViewModel @Inject constructor(
             // by the time this load completes; in any case the StateFlow is the
             // source of truth.
             val liveEntitled = entitlementRepository.entitlement.value.active
+            // Tutorial-seen flags live in their own DataStore keys; the
+            // STATE_JSON copy may be stale if the debounced state save was
+            // cancelled by a sensor event right after the user finished a
+            // tutorial. The dedicated keys are written synchronously on
+            // transition, so they're the authoritative source.
+            val tutorialSeen = userPreferencesRepository.readTutorialSeenFlags()
             val initialState = (savedState ?: CueDetatState()).copy(
                 experienceMode = currentExperienceMode,
                 savedFeltSamples = savedFeltSamples,
-                isExpertEntitled = liveEntitled
+                isExpertEntitled = liveEntitled,
+                hasSeenBeginnerTutorial = tutorialSeen.beginner,
+                hasSeenDynamicBeginnerTutorial = tutorialSeen.dynamicBeginner,
+                hasSeenExpertTutorial = tutorialSeen.expert,
             )
             processAndEmitState(initialState, UpdateType.FULL)
 
@@ -422,6 +431,31 @@ class MainViewModel @Inject constructor(
         _uiState.value = derivedState
         visionAnalyzer.updateUiState(derivedState)
         arFrameProcessor.updateUiState(derivedState)
+
+        // Persist tutorial-seen flags the moment they flip. They live in
+        // dedicated DataStore keys (not STATE_JSON) so they're not subject to
+        // the 2-second debounce on the state save, which can be cancelled
+        // indefinitely by the sensor-driven FullOrientationChanged stream
+        // before it ever lands. Without this, the user finishes a tutorial,
+        // sensor events keep cancelling the save, the app gets killed, and
+        // next launch the tutorial fires again.
+        val seenChanged =
+            derivedState.hasSeenBeginnerTutorial != previousState.hasSeenBeginnerTutorial ||
+            derivedState.hasSeenDynamicBeginnerTutorial != previousState.hasSeenDynamicBeginnerTutorial ||
+            derivedState.hasSeenExpertTutorial != previousState.hasSeenExpertTutorial
+        if (seenChanged) {
+            viewModelScope.launch {
+                runCatching {
+                    userPreferencesRepository.setTutorialSeenFlags(
+                        beginner = derivedState.hasSeenBeginnerTutorial,
+                        dynamicBeginner = derivedState.hasSeenDynamicBeginnerTutorial,
+                        expert = derivedState.hasSeenExpertTutorial,
+                    )
+                }.onFailure {
+                    android.util.Log.e("MainViewModel", "tutorial-seen flag save failed", it)
+                }
+            }
+        }
 
         if (derivedState.cameraMode == CameraMode.META_GLASSES) {
             metaWearableRepository.startStreaming()


### PR DESCRIPTION
## Summary

The Beginner and Expert tutorials were firing every time the user opened the corresponding mode, instead of only on first entry.

**Root cause**: the `hasSeen*Tutorial` flags lived inside the persisted `STATE_JSON` blob, which is written via a 2-second debounced `saveJob` in `MainViewModel`. Every state emit cancels the previous save job and `FullOrientationChanged` is published at the sensor rate. So when the user tapped "Done" on a tutorial and the reducer flipped the flag, the very next sensor event cancelled the save before the 2-second delay elapsed — and the next sensor event did the same. The flag transition never reached disk, so on the next launch `handleSetExperienceMode` saw `hasSeenBeginnerTutorial = false` and showed the tutorial again.

**Fix**: store the seen flags as dedicated `DataStore` boolean keys (same pattern the codebase previously used for the onboarding paywall flag), written **immediately** via a non-debounced `viewModelScope.launch` whenever any of them transitions false→true. On startup, the dedicated keys overlay the loaded state JSON so the in-memory flag reflects disk authority.

## Behavior

- Each tutorial (BEGINNER_STATIC, BEGINNER_DYNAMIC, GENERAL) now fires automatically exactly once — on first entry to its mode.
- The Help menu's manual "Start Tutorial" entry is unchanged; users can still re-trigger a tutorial deliberately.

## Test plan

- [ ] Cold launch on a fresh install → enter Beginner mode → tutorial fires
- [ ] Tap Done → switch to Expert → switch back to Beginner → no tutorial
- [ ] Kill app immediately after tapping Done (don't give the debounced save time to land) → relaunch → enter Beginner → still no tutorial (the dedicated key was written immediately)
- [ ] Enter Expert mode first time → Expert tutorial fires
- [ ] Tap Done → switch to Beginner → switch back to Expert → no tutorial
- [ ] Manual "Start Tutorial" from menu still works in both modes

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqmDFDMFcSoZ2CZJPtDQMY)_

## Summary by Sourcery

Persist tutorial completion flags independently of the main debounced state JSON so tutorials only auto-run once per mode.

Bug Fixes:
- Ensure beginner, dynamic beginner, and expert tutorials no longer re-trigger automatically after being completed when reopening modes or relaunching the app.

Enhancements:
- Load tutorial completion flags from dedicated DataStore keys on startup so in-memory state reflects the authoritative persisted values.