### PR TITLE
ci+deps: add release-build workflow; bump Netty/Bouncy Castle past CVEs

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -1,0 +1,306 @@
+name: Android Release Build
+
+# Triggers:
+#  - Manual run (workflow_dispatch) with an optional tag name override.
+#  - Pushing a "v*" tag (e.g. v1.8.0) to create a tagged release automatically.
+#
+# Unlike android_debug_apk_release.yml, this workflow:
+#  - Builds the FOSS *release* APK (assembleFossRelease) with R8/minification.
+#  - Signs the APK with the production keystore.
+#  - Publishes a non-prerelease GitHub Release with the signed APK attached.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for the release (e.g. v1.8.0). Leave blank to derive from version.properties.'
+        required: false
+        default: ''
+      release_notes:
+        description: 'Optional release notes. Defaults to commit SHA reference.'
+        required: false
+        default: ''
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      checks: read
+      packages: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Inject Google Services
+        env:
+          GOOGLE_SERVICES_API_KEY: ${{ secrets.GOOGLE_SERVICES_API_KEY }}
+          PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+        run: |
+          if [ -f "app/google-services.json.template" ]; then
+            echo "Template found. Injecting secrets..."
+            sed -e 's/{{\([^}]*\)}}/${\1}/g' app/google-services.json.template | envsubst > app/google-services.json
+          else
+            echo "Warning: google-services.json.template not found. Skipping injection."
+          fi
+
+      - name: Generate Keystore from Secrets
+        env:
+          KEYSTORE_PRIVATE: ${{ secrets.KEYSTORE_PRIVATE }}
+          KEYSTORE_CHAIN: ${{ secrets.KEYSTORE_CHAIN }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        run: |
+          echo "Generating keystore from certificate chain and private key..."
+
+          echo "$KEYSTORE_PRIVATE" > private_key.pem
+          echo "$KEYSTORE_CHAIN" > certificate_chain.crt
+
+          openssl pkcs12 -export -in certificate_chain.crt -inkey private_key.pem \
+            -name "$KEY_ALIAS" -out keystore.p12 \
+            -password pass:"$KEYSTORE_PASSWORD"
+
+          keytool -importkeystore -srckeystore keystore.p12 -srcstoretype PKCS12 \
+            -destkeystore app/keystore.jks -deststoretype JKS \
+            -srcstorepass "$KEYSTORE_PASSWORD" \
+            -deststorepass "$KEYSTORE_PASSWORD" \
+            -alias "$KEY_ALIAS" -noprompt
+
+          echo "Keystore generated successfully at app/keystore.jks"
+
+          rm private_key.pem certificate_chain.crt keystore.p12
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
+          dependency-graph: disabled
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build Release APK with Gradle
+        id: gradle-build
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          export BUILD_NUMBER=$(git rev-list --count HEAD)
+
+          ./gradlew assembleFossRelease -PversionBuild=$BUILD_NUMBER --build-cache \
+            -Pandroid.injected.signing.store.file=$(pwd)/app/keystore.jks \
+            -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
+            -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
+            -Pandroid.injected.signing.key.password=$KEY_PASSWORD > build.log 2>&1
+
+          EXIT_CODE=$?
+          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+          cat build.log
+          exit $EXIT_CODE
+
+      - name: Verify FOSS Release APK contains no Play Billing classes
+        if: success() && steps.gradle-build.outcome == 'success'
+        run: |
+          set -e
+          APK=$(find app/build/outputs/apk/foss/release -name "*.apk" | head -n 1)
+          if [ -z "$APK" ]; then
+            echo "Error: no FOSS release APK found to verify."
+            exit 1
+          fi
+          BUILD_TOOLS_DIR=$(ls -d "$ANDROID_HOME"/build-tools/* | tail -n 1)
+          DEXDUMP="$BUILD_TOOLS_DIR/dexdump"
+          if [ ! -x "$DEXDUMP" ]; then
+            echo "Error: dexdump not found at $DEXDUMP"
+            exit 1
+          fi
+          TMPDIR=$(mktemp -d)
+          unzip -q "$APK" -d "$TMPDIR"
+          FOUND=0
+          for DEX in "$TMPDIR"/classes*.dex; do
+            if "$DEXDUMP" "$DEX" 2>/dev/null | grep -q "com/android/billingclient"; then
+              echo "ERROR: billing client class found in $DEX of FOSS release APK!"
+              FOUND=1
+            fi
+          done
+          rm -rf "$TMPDIR"
+          if [ "$FOUND" = "1" ]; then
+            exit 1
+          fi
+          echo "OK: FOSS release APK contains no com.android.billingclient classes."
+
+      - name: Verify Release APK is signed (not debug)
+        if: success() && steps.gradle-build.outcome == 'success'
+        env:
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        run: |
+          set -e
+          APK=$(find app/build/outputs/apk/foss/release -name "*.apk" | head -n 1)
+          BUILD_TOOLS_DIR=$(ls -d "$ANDROID_HOME"/build-tools/* | tail -n 1)
+          APKSIGNER="$BUILD_TOOLS_DIR/apksigner"
+          if [ ! -x "$APKSIGNER" ]; then
+            echo "Error: apksigner not found at $APKSIGNER"
+            exit 1
+          fi
+          "$APKSIGNER" verify --verbose "$APK"
+          # Refuse to publish an APK signed by the default Android debug keystore.
+          SIGNER_INFO=$("$APKSIGNER" verify --print-certs "$APK")
+          echo "$SIGNER_INFO"
+          if echo "$SIGNER_INFO" | grep -q "CN=Android Debug"; then
+            echo "ERROR: APK is signed with the Android debug keystore — refusing to publish a debug-signed release."
+            exit 1
+          fi
+          echo "OK: Release APK is signed with a non-debug certificate."
+
+      - name: Report Failure to Jules
+        if: failure() && steps.gradle-build.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            let logTail = 'Log file not found.';
+            try { logTail = fs.readFileSync('build.log', 'utf8').slice(-4000); } catch (e) {}
+
+            const assignee = 'gemini-code-assist';
+
+            try {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Release Build Failure on ${context.ref}`,
+                body: `@${assignee} /jules debug this release build error\n\n**Log:**\n\`\`\`\n${logTail}\n\`\`\``,
+                labels: ['jules', 'bug', 'release'],
+                assignees: [assignee]
+              });
+            } catch (error) {
+              console.log("Failed to create issue with assignee. Retrying without assignee.");
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Release Build Failure on ${context.ref}`,
+                body: `@${assignee} /jules debug this release build error\n\n**Log:**\n\`\`\`\n${logTail}\n\`\`\``,
+                labels: ['jules', 'bug', 'release']
+              });
+            }
+
+      - name: Prepare Release Variables
+        if: success()
+        id: release_vars
+        run: |
+          export BUILD_NUMBER=$(git rev-list --count HEAD)
+
+          MAJOR=$(grep '^MAJOR=' version.properties | cut -d'=' -f2)
+          MINOR=$(grep '^MINOR=' version.properties | cut -d'=' -f2)
+
+          MINOR_COMMIT=$(git blame -L '/^MINOR=/',+1 version.properties | awk '{print $1}' | tr -d '^')
+          if [ -n "$MINOR_COMMIT" ]; then
+            PATCH=$(git rev-list --count $MINOR_COMMIT..HEAD)
+          else
+            PATCH=$(grep '^PATCH=' version.properties | cut -d'=' -f2)
+          fi
+
+          VERSION_NAME="$MAJOR.$MINOR.$PATCH.$BUILD_NUMBER"
+
+          # Tag resolution order:
+          #  1) workflow_dispatch input override
+          #  2) the pushed tag (when triggered by a v* tag push)
+          #  3) derived "v<MAJOR>.<MINOR>.<PATCH>" from version.properties
+          INPUT_TAG="${{ github.event.inputs.tag_name }}"
+          if [ -n "$INPUT_TAG" ]; then
+            TAG_NAME="$INPUT_TAG"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG_NAME="${GITHUB_REF#refs/tags/}"
+          else
+            TAG_NAME="v${MAJOR}.${MINOR}.${PATCH}"
+          fi
+
+          if [ -f "settings.gradle.kts" ]; then
+             APP_NAME=$(grep 'rootProject.name' settings.gradle.kts | sed -E "s/.*=.*[\"'](.*)[\"']/\1/")
+          elif [ -f "settings.gradle" ]; then
+             APP_NAME=$(grep 'rootProject.name' settings.gradle | sed -E "s/.*=.*[\"'](.*)[\"']/\1/")
+          else
+             APP_NAME="App"
+          fi
+
+          APK_ORIGINAL=$(find app/build/outputs/apk/foss/release -name "*.apk" | head -n 1)
+
+          if [ -z "$APK_ORIGINAL" ]; then
+             echo "Error: No release APK found to release!"
+             exit 1
+          fi
+
+          TARGET_NAME="${APP_NAME}-${VERSION_NAME}-release.apk"
+          mv "$APK_ORIGINAL" "$TARGET_NAME"
+
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+          echo "APK_FILE=$TARGET_NAME" >> $GITHUB_ENV
+          echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
+
+          mkdir -p build_tools_package/tools build_tools_package/native
+          [ -d "app/src/main/assets/tools" ] && cp -r app/src/main/assets/tools/* build_tools_package/tools/ || true
+          [ -d "app/src/main/jniLibs/arm64-v8a" ] && cp -r app/src/main/jniLibs/arm64-v8a/* build_tools_package/native/ || true
+          cd build_tools_package && zip -r ../build-tools.zip . && cd ..
+
+      - name: Publish Release
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CUSTOM_NOTES: ${{ github.event.inputs.release_notes }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Only create/move the tag when the workflow wasn't itself triggered
+          # by a tag push (otherwise the tag already exists at this commit).
+          if [[ "$GITHUB_REF" != refs/tags/* ]]; then
+            git tag -fa "$TAG_NAME" -m "Release $TAG_NAME"
+            git push origin "$TAG_NAME" --force
+          fi
+
+          BUILD_TOOLS="build-tools.zip"
+
+          if [ -n "$CUSTOM_NOTES" ]; then
+            NOTES="$CUSTOM_NOTES"
+          else
+            NOTES="Release $VERSION_NAME built from commit $GITHUB_SHA"
+          fi
+
+          if gh release view "$TAG_NAME" > /dev/null 2>&1; then
+             echo "Updating existing release..."
+             gh release delete-asset "$TAG_NAME" "$BUILD_TOOLS" -y || true
+             gh release edit "$TAG_NAME" --prerelease=false --draft=false \
+               --title "Release $TAG_NAME" \
+               --notes "$NOTES" \
+               --target "$GITHUB_SHA"
+             gh release upload "$TAG_NAME" "$APK_FILE" --clobber
+             [ -f "$BUILD_TOOLS" ] && gh release upload "$TAG_NAME" "$BUILD_TOOLS" --clobber
+          else
+             echo "Creating new release..."
+             gh release create "$TAG_NAME" "$APK_FILE" \
+               --title "Release $TAG_NAME" \
+               --notes "$NOTES" \
+               --target "$GITHUB_SHA"
+             [ -f "$BUILD_TOOLS" ] && gh release upload "$TAG_NAME" "$BUILD_TOOLS" --clobber
+          fi

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -397,15 +397,6 @@ dependencies {
         implementation(libs.guava.vulnerability) {
             because("Transitive dependency vulnerability")
         }
-        implementation(libs.bouncycastle.bcprov) {
-            because("CVE-2026-5598 covert timing channel + CVE-2026-0636 LDAP injection in older bcprov-jdk18on")
-        }
-        implementation(libs.bouncycastle.bcpkix) {
-            because("Broken/risky cryptographic algorithm vulnerability in older bcpkix-jdk18on")
-        }
-        implementation(libs.bouncycastle.bcutil) {
-            because("Pin bcutil-jdk18on alongside bcprov/bcpkix to keep Bouncy Castle modules in lockstep")
-        }
     }
 }
 
@@ -415,13 +406,9 @@ configurations.all {
             useVersion(libs.versions.netty.get())
             because("Transitive dependency vulnerabilities in testing/grpc")
         }
-        if (requested.group == "org.bouncycastle" &&
-            (requested.name == "bcprov-jdk18on" ||
-                requested.name == "bcpkix-jdk18on" ||
-                requested.name == "bcutil-jdk18on")
-        ) {
+        if (requested.group == "org.bouncycastle") {
             useVersion(libs.versions.bouncycastle.get())
-            because("Force-upgrade transitive Bouncy Castle modules past CVE-2026-5598 / CVE-2026-0636 / bcpkix algorithm issues")
+            because("Force-upgrade Bouncy Castle modules to fix vulnerabilities and ensure version alignment")
         }
     }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -397,6 +397,15 @@ dependencies {
         implementation(libs.guava.vulnerability) {
             because("Transitive dependency vulnerability")
         }
+        implementation(libs.bouncycastle.bcprov) {
+            because("CVE-2026-5598 covert timing channel + CVE-2026-0636 LDAP injection in older bcprov-jdk18on")
+        }
+        implementation(libs.bouncycastle.bcpkix) {
+            because("Broken/risky cryptographic algorithm vulnerability in older bcpkix-jdk18on")
+        }
+        implementation(libs.bouncycastle.bcutil) {
+            because("Pin bcutil-jdk18on alongside bcprov/bcpkix to keep Bouncy Castle modules in lockstep")
+        }
     }
 }
 
@@ -405,6 +414,14 @@ configurations.all {
         if (requested.group == "io.netty") {
             useVersion(libs.versions.netty.get())
             because("Transitive dependency vulnerabilities in testing/grpc")
+        }
+        if (requested.group == "org.bouncycastle" &&
+            (requested.name == "bcprov-jdk18on" ||
+                requested.name == "bcpkix-jdk18on" ||
+                requested.name == "bcutil-jdk18on")
+        ) {
+            useVersion(libs.versions.bouncycastle.get())
+            because("Force-upgrade transitive Bouncy Castle modules past CVE-2026-5598 / CVE-2026-0636 / bcpkix algorithm issues")
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -193,9 +193,6 @@ mwdat-mockdevice = { group = "com.meta.wearable", name = "mwdat-mockdevice", ver
 jose4j = { group = "org.bitbucket.b_c", name = "jose4j", version.ref = "jose4j" }
 guava-vulnerability = { group = "com.google.guava", name = "guava", version.ref = "guavaVulnerability" }
 netty-all = { group = "io.netty", name = "netty-all", version.ref = "netty" }
-bouncycastle-bcprov = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }
-bouncycastle-bcpkix = { group = "org.bouncycastle", name = "bcpkix-jdk18on", version.ref = "bouncycastle" }
-bouncycastle-bcutil = { group = "org.bouncycastle", name = "bcutil-jdk18on", version.ref = "bouncycastle" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidApplication" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,7 +86,8 @@ onnxruntimeAndroid = "1.26.0"
 metaWearableDat = "0.6.0"
 jose4j = "0.9.6"
 guavaVulnerability = "33.6.0-android"
-netty = "4.1.132.Final"
+netty = "4.1.133.Final"
+bouncycastle = "1.84"
 androidx-billing = "8.3.0"
 play-integrity = "1.6.0"
 androidxCredentials = "1.5.0"
@@ -192,6 +193,9 @@ mwdat-mockdevice = { group = "com.meta.wearable", name = "mwdat-mockdevice", ver
 jose4j = { group = "org.bitbucket.b_c", name = "jose4j", version.ref = "jose4j" }
 guava-vulnerability = { group = "com.google.guava", name = "guava", version.ref = "guavaVulnerability" }
 netty-all = { group = "io.netty", name = "netty-all", version.ref = "netty" }
+bouncycastle-bcprov = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-bcpkix = { group = "org.bouncycastle", name = "bcpkix-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-bcutil = { group = "org.bouncycastle", name = "bcutil-jdk18on", version.ref = "bouncycastle" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidApplication" }


### PR DESCRIPTION
## Summary

- **New release workflow** (`.github/workflows/android_release.yml`) builds a real, signed, R8-minified FOSS release APK via `assembleFossRelease` — not a debug build. Triggers on `v*` tag pushes or manual `workflow_dispatch` (with optional tag/notes overrides). Refuses to publish if the APK ends up signed by the Android debug keystore, then creates a non-prerelease GitHub release. The existing `android_debug_apk_release.yml` is left alone, so per-commit debug builds continue to flow.
- **Netty → 4.1.133.Final** (was 4.1.132.Final) via `libs.versions.toml`. The existing `resolutionStrategy.eachDependency` block already forces every `io.netty:*` transitive to this version, so all of the following alerts get cleared in one bump:
  - #34 / #33 — `HttpContentDecompressor` maxAllocation bypass (br/zstd/snappy decompression bomb DoS)
  - #30 — `Lz4FrameDecoder` resource exhaustion
  - #31 — `HttpClientCodec` response desynchronization
  - #28 / #32 — HTTP request smuggling (chunk size parsing, malformed Transfer-Encoding)
  - #26 — Start-Line injection in `DefaultHttpRequest.setUri()` (HTTP smuggling / RTSP injection)
  - #29 — HTTP/1.0 TE+CL coexistence bypass
  - #27 — `HttpProxyHandler` header injection (incomplete fix for CVE-2025-67735)
- **Bouncy Castle → 1.84** pinned via `constraints { … }` and a `resolutionStrategy` rule for `bcprov-jdk18on`, `bcpkix-jdk18on`, and `bcutil-jdk18on`. BC isn't a direct dep — it comes in transitively — so the pin is what actually moves the resolved version. Clears:
  - #25 — covert timing channel in `bcprov-jdk18on` (CVE-2026-5598, FrodoKEM sampling)
  - #24 — LDAP injection in `bcprov-jdk18on` (CVE-2026-0636)
  - #23 — broken/risky cryptographic algorithm in `bcpkix-jdk18on`

## Test plan

- [ ] CI: `assembleFossDebug` (existing workflow) still green on this branch.
- [ ] Manually trigger **Android Release Build** via `workflow_dispatch` once secrets are confirmed configured; verify the resulting GitHub release is non-prerelease and the APK signature passes `apksigner verify` against the production cert.
- [ ] `./gradlew app:dependencies --configuration fossReleaseRuntimeClasspath | grep -E 'bouncycastle|netty'` shows `1.84` for all BC modules and `4.1.133.Final` for all Netty modules.
- [ ] Confirm Dependabot alerts #23–#34 close after the PR merges and the next scan runs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Esjkez9CZLCugJujuc8reZ)_

## Summary by Sourcery

Introduce an automated FOSS Android release workflow and bump vulnerable transitive libraries to secure versions.

New Features:
- Add a GitHub Actions workflow to build, sign, verify, and publish FOSS release APKs on version tags or manual triggers.

Enhancements:
- Pin Netty dependencies to version 4.1.133.Final via the shared versions catalog to align all transitive Netty modules.
- Force all org.bouncycastle dependencies to resolve to version 1.84 to keep cryptography libraries aligned and up to date.

Build:
- Update Gradle dependency resolution to enforce specific Netty and Bouncy Castle versions across all configurations.

CI:
- Add CI automation that generates the release keystore from secrets, validates the resulting APK (including billing-free FOSS checks and non-debug signing), and creates or updates GitHub Releases with bundled artifacts, including build tools.