### PR TITLE
ci: use GH_TOKEN PAT for GitHubPackages auth in release builds

### DIFF
--- a/.github/workflows/android_debug_apk_release.yml
+++ b/.github/workflows/android_debug_apk_release.yml
@@ -96,7 +96,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           set +e
           export BUILD_NUMBER=$(git rev-list --count HEAD)

--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -104,7 +104,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           set +e
           export BUILD_NUMBER=$(git rev-list --count HEAD)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: ./gradlew clean assembleRelease -PversionCode=${{ steps.versioning.outputs.new_version_code }} -PversionName=${{ steps.versioning.outputs.new_version_name }}
 
       - name: Rename APK


### PR DESCRIPTION
## Summary
- `settings.gradle.kts` authenticates to `maven.pkg.github.com/facebook/meta-wearables-dat-android` using the `GITHUB_TOKEN` env var, but the default `secrets.GITHUB_TOKEN` is scoped to this repo and returns 401 against Facebook's GitHub Packages — `mwdat-core` / `mwdat-camera` fail to resolve and `assembleRelease` aborts.
- Point the Gradle build steps in `release.yml`, `android_release.yml`, and `android_debug_apk_release.yml` at `secrets.GH_TOKEN` (PAT with `read:packages`) instead. `release.yml` had no token wired at all; the other two were using the wrong one.
- The downstream `gh release` / `actions/github-script` steps still use `secrets.GITHUB_TOKEN` — only the Gradle build step swaps to `GH_TOKEN`.

## Test plan
- [ ] On push to `main`, `release.yml` resolves `com.meta.wearable:mwdat-*` and `assembleRelease` succeeds
- [ ] `android_release.yml` `assembleFossRelease` succeeds
- [ ] `android_debug_apk_release.yml` `assembleFossDebug` succeeds
- [ ] GitHub release publishing in those workflows still works (still uses `secrets.GITHUB_TOKEN`)

Prereq: a repo secret named `GH_TOKEN` must exist with `read:packages` access to `facebook/meta-wearables-dat-android`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D9Wp4XBCzBsnG595Brsrst)_