### PR TITLE
ci: build foss-only in release.yml and fix APK output path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,22 +91,19 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: ./gradlew clean assembleRelease -PversionCode=${{ steps.versioning.outputs.new_version_code }} -PversionName=${{ steps.versioning.outputs.new_version_name }}
+        run: ./gradlew clean assembleFossRelease -PversionCode=${{ steps.versioning.outputs.new_version_code }} -PversionName=${{ steps.versioning.outputs.new_version_name }}
 
       - name: Rename APK
         id: rename_apk
         run: |
-          # Find the signed APK
-          APK_PATH=$(find ./app/build/outputs/apk/release -name "app-release.apk")
+          APK_PATH=$(find ./app/build/outputs/apk/foss/release -name "*.apk" | head -n 1)
+          if [ -z "$APK_PATH" ]; then
+            echo "Error: no FOSS release APK found."
+            exit 1
+          fi
           APK_DIR=$(dirname "$APK_PATH")
-          
-          # Create the new filename
           NEW_APK_NAME="Cue-Detat-v${{ steps.versioning.outputs.new_version_name }}.apk"
-          
-          # Rename the file
           mv "$APK_PATH" "$APK_DIR/$NEW_APK_NAME"
-          
-          # Set output for the upload step
           echo "new_path=$APK_DIR/$NEW_APK_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Pre-Release


### PR DESCRIPTION
## Summary
- `assembleRelease` produces both `app/build/outputs/apk/play/release/app-play-release.apk` and `app/build/outputs/apk/foss/release/app-foss-release.apk` — never `apk/release/`. The Rename APK step's `find` returned empty and exited 1.
- Only foss ships on GitHub Releases (play is reserved for AAB uploads to the Play Console), so build only `assembleFossRelease` and look for the APK in `app/build/outputs/apk/foss/release/`. Same path pattern android_release.yml already uses.

## Test plan
- [ ] Push to main → `release.yml` runs `assembleFossRelease`, finds the APK, attaches `Cue-Detat-v<version>.apk` to the `v1.3-debug` prerelease.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D9Wp4XBCzBsnG595Brsrst)_