### PR TITLE
Fix tester auto-unlock, dynamic-mode zoom lag, tutorial dismiss, ML boxes, and FOSS auto-update

### DIFF
--- a/app/src/foss/AndroidManifest.xml
+++ b/app/src/foss/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- FOSS-only: the in-app updater sideloads release APKs from GitHub.
+         These are intentionally absent from the Play build, where Google Play
+         owns updates. -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
+    <application>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+    </application>
+</manifest>

--- a/app/src/foss/java/com/hereliesaz/cuedetat/di/FossUpdateModule.kt
+++ b/app/src/foss/java/com/hereliesaz/cuedetat/di/FossUpdateModule.kt
@@ -1,0 +1,21 @@
+// FILE: app/src/foss/java/com/hereliesaz/cuedetat/di/FossUpdateModule.kt
+
+package com.hereliesaz.cuedetat.di
+
+import com.hereliesaz.cuedetat.update.AppUpdater
+import com.hereliesaz.cuedetat.update.FossAppUpdater
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/** Binds the GitHub-releases self-updater for FOSS builds. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class FossUpdateModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindAppUpdater(impl: FossAppUpdater): AppUpdater
+}

--- a/app/src/foss/java/com/hereliesaz/cuedetat/update/FossAppUpdater.kt
+++ b/app/src/foss/java/com/hereliesaz/cuedetat/update/FossAppUpdater.kt
@@ -1,0 +1,126 @@
+// FILE: app/src/foss/java/com/hereliesaz/cuedetat/update/FossAppUpdater.kt
+
+package com.hereliesaz.cuedetat.update
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import android.util.Log
+import androidx.core.content.FileProvider
+import com.hereliesaz.cuedetat.BuildConfig
+import com.hereliesaz.cuedetat.data.GithubRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * FOSS-flavor self-updater. Checks the project's GitHub releases and, when a
+ * newer build is available, downloads the release APK and hands it to the
+ * system package installer. This is the closest to "auto-update" Android
+ * permits for a normally-installed (non device-owner) app — the OS always
+ * shows its own install confirmation, which matches the agreed one-tap popup.
+ */
+@Singleton
+class FossAppUpdater @Inject constructor(
+    @ApplicationContext private val context: android.content.Context,
+    private val githubRepository: GithubRepository,
+) : AppUpdater {
+
+    private val client by lazy { OkHttpClient() }
+
+    override val isSupported: Boolean = true
+
+    override suspend fun checkForUpdate(): UpdateInfo? {
+        val release = githubRepository.getLatestRelease() ?: return null
+        val tag = release.tag_name
+        if (!isNewerVersion(tag, BuildConfig.VERSION_NAME)) return null
+
+        // Prefer a FOSS-named APK asset, then any APK.
+        val apk = release.assets.firstOrNull {
+            it.name.endsWith(".apk", ignoreCase = true) && it.name.contains("foss", ignoreCase = true)
+        } ?: release.assets.firstOrNull { it.name.endsWith(".apk", ignoreCase = true) }
+
+        return UpdateInfo(
+            versionName = tag.removePrefix("v").removePrefix("V"),
+            apkUrl = apk?.browser_download_url,
+            releaseUrl = release.html_url,
+        )
+    }
+
+    override suspend fun downloadAndInstall(activity: Activity, info: UpdateInfo) {
+        val url = info.apkUrl
+        if (url.isNullOrBlank()) {
+            // No APK asset — fall back to opening the release page.
+            info.releaseUrl?.let { openUrl(activity, it) }
+            return
+        }
+
+        // Installing from an APK requires the user to have granted this app the
+        // "install unknown apps" permission. Route them to the system screen if
+        // they haven't, then let them retry.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            !context.packageManager.canRequestPackageInstalls()
+        ) {
+            runCatching {
+                activity.startActivity(
+                    Intent(
+                        Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                        Uri.parse("package:${context.packageName}"),
+                    ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                )
+            }
+            return
+        }
+
+        val apkFile = withContext(Dispatchers.IO) { downloadApk(url) } ?: run {
+            Log.w(TAG, "downloadAndInstall: download failed; opening release page")
+            info.releaseUrl?.let { openUrl(activity, it) }
+            return
+        }
+
+        val uri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            apkFile,
+        )
+        val installIntent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/vnd.android.package-archive")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        runCatching { activity.startActivity(installIntent) }
+            .onFailure { Log.e(TAG, "Failed to launch installer", it) }
+    }
+
+    private fun downloadApk(url: String): File? {
+        return runCatching {
+            val dir = File(context.cacheDir, "updates").apply { mkdirs() }
+            val out = File(dir, "cuedetat-update.apk")
+            val request = Request.Builder().url(url).build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return null
+                val body = response.body ?: return null
+                out.outputStream().use { sink -> body.byteStream().copyTo(sink) }
+            }
+            out
+        }.getOrNull()
+    }
+
+    private fun openUrl(activity: Activity, url: String) {
+        runCatching {
+            activity.startActivity(
+                Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        }
+    }
+
+    companion object {
+        private const val TAG = "FossAppUpdater"
+    }
+}

--- a/app/src/foss/res/xml/file_paths.xml
+++ b/app/src/foss/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!-- The downloaded update APK lives in cacheDir/updates (see FossAppUpdater). -->
+    <cache-path name="updates" path="updates/" />
+</paths>

--- a/app/src/main/java/com/hereliesaz/cuedetat/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/MainActivity.kt
@@ -117,6 +117,9 @@ class MainActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         viewModel.refreshEntitlement()
+        // Silently unlock Expert for allowlisted testers without requiring them
+        // to open the paywall. Self-guards and never prompts.
+        viewModel.attemptTesterAutoUnlock(this)
     }
 
     private fun observeSingleEvents() {
@@ -169,6 +172,7 @@ class MainActivity : ComponentActivity() {
     @Composable
     private fun AppContent() {
         val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+        val updateInfo by viewModel.updateInfo.collectAsStateWithLifecycle()
         val showSplashScreen = uiState.experienceMode == null
         var haterModeLockedOrientation by rememberSaveable { mutableStateOf(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED) }
 
@@ -192,6 +196,14 @@ class MainActivity : ComponentActivity() {
         }
 
         CueDetatTheme(luminanceAdjustment = uiState.luminanceAdjustment) {
+            updateInfo?.let { info ->
+                com.hereliesaz.cuedetat.ui.composables.dialogs.AppUpdateDialog(
+                    versionName = info.versionName,
+                    onInstall = { viewModel.installUpdate(this@MainActivity) },
+                    onDismiss = { viewModel.dismissUpdate() }
+                )
+            }
+
             paywallTrigger?.let { trigger ->
                 // key(paywallShowSequence): force a fresh composition (and
                 // fresh ModalBottomSheet animation) on every show request,

--- a/app/src/main/java/com/hereliesaz/cuedetat/billing/Entitlement.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/billing/Entitlement.kt
@@ -45,4 +45,11 @@ enum class EntitlementSource {
      * apply.
      */
     TESTER_LICENSE,
+
+    /**
+     * Temporary, time-limited Expert access from the one-time free preview.
+     * `expiresAtMillis` is set; once it passes the entitlement reverts to
+     * inactive. One per install.
+     */
+    TRIAL,
 }

--- a/app/src/main/java/com/hereliesaz/cuedetat/billing/EntitlementRepository.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/billing/EntitlementRepository.kt
@@ -78,6 +78,20 @@ interface EntitlementRepository {
 
     /** Whether the Credential Manager flow is available in this build. */
     val isCredentialManagerAvailable: Boolean get() = false
+
+    /**
+     * Start the one-time, time-limited Expert preview. Returns true if a fresh
+     * trial was started, false if it was already used or the user is already
+     * entitled. Grants a [EntitlementSource.TRIAL] entitlement that expires
+     * automatically. No-op in FOSS (already entitled).
+     */
+    suspend fun startExpertTrial(): Boolean = false
+
+    /**
+     * Whether the one-time Expert preview has not yet been used and could be
+     * started. False in FOSS (no paywall) and once the trial has been consumed.
+     */
+    val isExpertTrialAvailable: Boolean get() = false
 }
 
 sealed class TesterLicenseResult {

--- a/app/src/main/java/com/hereliesaz/cuedetat/data/GithubRepository.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/GithubRepository.kt
@@ -32,4 +32,18 @@ class GithubRepository @Inject constructor(private val githubApi: GithubApi) {
             null
         }
     }
+
+    /**
+     * Fetches the full latest release (tag, name, html_url, and downloadable
+     * assets), or null on any failure. Used by the FOSS in-app updater to
+     * locate the APK to download.
+     */
+    suspend fun getLatestRelease(): com.hereliesaz.cuedetat.network.GithubRelease? {
+        return try {
+            val response = githubApi.getLatestRelease(REPO_OWNER, REPO_NAME)
+            if (response.isSuccessful) response.body() else null
+        } catch (e: Exception) {
+            null
+        }
+    }
 }

--- a/app/src/main/java/com/hereliesaz/cuedetat/data/MergedTFLiteDetector.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/MergedTFLiteDetector.kt
@@ -6,6 +6,7 @@ import android.graphics.PointF
 import android.graphics.RectF
 import android.os.Build
 import android.util.Log
+import com.hereliesaz.cuedetat.BuildConfig
 import com.hereliesaz.cuedetat.ui.composables.tablescan.MlTableDetection
 import com.hereliesaz.cuedetat.ui.composables.tablescan.PocketDetector
 import org.tensorflow.lite.Interpreter
@@ -209,10 +210,35 @@ class MergedTFLiteDetector(private val context: Context) : PocketDetector {
             preprocess(bitmap)
             val output = Array(1) { Array(MAX_DETECTIONS) { FloatArray(6) } }
             interp.run(inputBuffer, output)
+            if (BuildConfig.DEBUG) logRawOutput("pool", output)
             parsePoolDetections(output, bitmap.width, bitmap.height)
         } catch (e: Exception) {
             Log.e(TAG, "Pool inference failed: ${e.message}")
             emptyList()
+        }
+    }
+
+    /**
+     * Detection coordinate convention auto-detect. TFLite_Detection_PostProcess
+     * (the in-graph NMS these models use) emits normalized [0,1] box edges, but
+     * some YOLO TFLite exports emit input-pixel coordinates (0..[INPUT_SIZE])
+     * instead. If the largest edge looks like a pixel value, normalize by the
+     * input size so downstream width/height scaling lands the box on the ball
+     * either way. Without this, a pixel-coordinate export draws boxes ~640×
+     * too large and entirely off-screen — i.e. "the model does nothing".
+     */
+    private fun coordScale(det: FloatArray): Float {
+        val maxEdge = maxOf(det[0], det[1], det[2], det[3])
+        return if (maxEdge > 1.5f) 1f / INPUT_SIZE else 1f
+    }
+
+    /** Debug-only dump of the first few non-empty detection rows + tensor shape. */
+    private fun logRawOutput(tag: String, output: Array<Array<FloatArray>>) {
+        val rows = output[0]
+        val nonEmpty = rows.count { it[4] > 0f }
+        Log.d(TAG, "$tag raw output: [1, ${rows.size}, ${rows.firstOrNull()?.size ?: 0}], rows with score>0 = $nonEmpty")
+        rows.asSequence().filter { it[4] > 0.05f }.take(5).forEach {
+            Log.d(TAG, "  $tag det = [${it[0]}, ${it[1]}, ${it[2]}, ${it[3]}, score=${it[4]}, cls=${it[5]}]")
         }
     }
 
@@ -229,22 +255,23 @@ class MergedTFLiteDetector(private val context: Context) : PocketDetector {
             val score = det[4]
             if (score < CONFIDENCE_THRESHOLD) continue
             val classId = det[5].toInt()
+            val s = coordScale(det)
 
             when (classId) {
                 TABLE_CLASS_ID -> {
                     if (score > maxTableScore) {
                         maxTableScore = score
                         tableBoundary = RectF(
-                            det[1] * width,
-                            det[0] * height,
-                            det[3] * width,
-                            det[2] * height,
+                            det[1] * s * width,
+                            det[0] * s * height,
+                            det[3] * s * width,
+                            det[2] * s * height,
                         )
                     }
                 }
                 HOLE_CLASS_ID, SIDE_CLASS_ID -> {
-                    val cx = ((det[1] + det[3]) / 2f * width)
-                    val cy = ((det[0] + det[2]) / 2f * height)
+                    val cx = ((det[1] + det[3]) / 2f * s * width)
+                    val cy = ((det[0] + det[2]) / 2f * s * height)
                     pockets.add(PointF(cx, cy))
                 }
             }
@@ -266,11 +293,12 @@ class MergedTFLiteDetector(private val context: Context) : PocketDetector {
             val score = det[4]
             if (score < POOL_CONFIDENCE_THRESHOLD) continue
             val classId = det[5].toInt()
-            
-            val top = det[0] * height
-            val left = det[1] * width
-            val bottom = det[2] * height
-            val right = det[3] * width
+            val s = coordScale(det)
+
+            val top = det[0] * s * height
+            val left = det[1] * s * width
+            val bottom = det[2] * s * height
+            val right = det[3] * s * width
             results.add(PoolDetection(RectF(left, top, right, bottom), score, classId))
         }
         return results

--- a/app/src/main/java/com/hereliesaz/cuedetat/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/UserPreferencesRepository.kt
@@ -7,6 +7,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.google.gson.Gson
@@ -46,6 +47,20 @@ class UserPreferencesRepository @Inject constructor(
         val HAS_SEEN_BEGINNER_TUTORIAL = booleanPreferencesKey("has_seen_beginner_tutorial")
         val HAS_SEEN_DYNAMIC_BEGINNER_TUTORIAL = booleanPreferencesKey("has_seen_dynamic_beginner_tutorial")
         val HAS_SEEN_EXPERT_TUTORIAL = booleanPreferencesKey("has_seen_expert_tutorial")
+
+        // Epoch millis the one-time Expert preview/trial was started. 0 (absent)
+        // means the trial has never been used. A non-zero value both gates the
+        // trial (one per install) and lets the entitlement repo compute expiry.
+        val EXPERT_TRIAL_STARTED_AT = longPreferencesKey("expert_trial_started_at")
+    }
+
+    /** Epoch millis the Expert trial was started, or 0 if it never was. */
+    suspend fun readExpertTrialStartedAt(): Long =
+        dataStore.data.first()[PreferencesKeys.EXPERT_TRIAL_STARTED_AT] ?: 0L
+
+    /** Records the Expert trial start time. Persisted immediately so a kill mid-trial can't reset it. */
+    suspend fun setExpertTrialStartedAt(millis: Long) {
+        dataStore.edit { prefs -> prefs[PreferencesKeys.EXPERT_TRIAL_STARTED_AT] = millis }
     }
 
     data class TutorialSeenFlags(

--- a/app/src/main/java/com/hereliesaz/cuedetat/network/GithubApi.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/network/GithubApi.kt
@@ -6,10 +6,20 @@ import retrofit2.http.Path
 
 /**
  * A data class representing the relevant fields from a GitHub Release API response.
- * We only care about the tag name, which contains the version string.
+ * `tag_name` carries the version string; `assets` carry the downloadable APK(s)
+ * used by the FOSS in-app updater; `html_url` is the release page fallback.
  */
 data class GithubRelease(
-    val tag_name: String
+    val tag_name: String,
+    val name: String? = null,
+    val html_url: String? = null,
+    val assets: List<GithubAsset> = emptyList()
+)
+
+/** A single downloadable file attached to a GitHub release. */
+data class GithubAsset(
+    val name: String,
+    val browser_download_url: String
 )
 
 /**

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
@@ -76,7 +76,38 @@ class MainViewModel @Inject constructor(
     private val entitlementRepository: com.hereliesaz.cuedetat.billing.EntitlementRepository,
     private val integrityRepository: com.hereliesaz.cuedetat.data.IntegrityRepository,
     private val shotAdvisor: com.hereliesaz.cuedetat.domain.advisor.ShotAdvisor,
+    private val appUpdater: com.hereliesaz.cuedetat.update.AppUpdater,
 ) : ViewModel() {
+
+    /**
+     * FOSS self-update. Non-null when a newer GitHub release is available; the
+     * UI shows a one-tap "download & install" popup. Always null in Play
+     * (store-managed updates).
+     */
+    private val _updateInfo = kotlinx.coroutines.flow.MutableStateFlow<com.hereliesaz.cuedetat.update.UpdateInfo?>(null)
+    val updateInfo: kotlinx.coroutines.flow.StateFlow<com.hereliesaz.cuedetat.update.UpdateInfo?> =
+        _updateInfo.asStateFlow()
+
+    init {
+        if (appUpdater.isSupported) {
+            viewModelScope.launch {
+                runCatching { appUpdater.checkForUpdate() }.getOrNull()?.let { _updateInfo.value = it }
+            }
+        }
+    }
+
+    /** Download the available update APK and launch the system installer (FOSS only). */
+    fun installUpdate(activity: android.app.Activity) {
+        val info = _updateInfo.value ?: return
+        viewModelScope.launch {
+            runCatching { appUpdater.downloadAndInstall(activity, info) }
+        }
+    }
+
+    /** Dismiss the update popup for this session. */
+    fun dismissUpdate() {
+        _updateInfo.value = null
+    }
 
     /**
      * Forces a re-query of the user's Play subscription status. Called from
@@ -95,6 +126,30 @@ class MainViewModel @Inject constructor(
         lastEntitlementRefresh = now
         viewModelScope.launch {
             runCatching { entitlementRepository.refresh() }
+        }
+    }
+
+    /** Guards [attemptTesterAutoUnlock] so we only try the silent picker once per process. */
+    private var attemptedTesterAutoUnlock = false
+
+    /**
+     * Best-effort, no-prompt tester unlock on app start. If the user's Google
+     * account is already authorized for this app and is on the build-baked
+     * tester allowlist, this grants Expert Mode without them ever having to
+     * open the paywall and walk through the tester section. Previously the
+     * silent resolve only ran when the paywall sheet was opened, so an
+     * allowlisted tester who never opened it never got unlocked.
+     *
+     * Credential Manager requires an Activity, so this is Activity-bound and
+     * invoked from MainActivity. Safe to call on every resume — it self-guards
+     * (already entitled / already attempted) and never shows UI.
+     */
+    fun attemptTesterAutoUnlock(activity: android.app.Activity) {
+        if (attemptedTesterAutoUnlock) return
+        if (entitlementRepository.entitlement.value.active) return
+        attemptedTesterAutoUnlock = true
+        viewModelScope.launch {
+            runCatching { entitlementRepository.silentlyResolveTesterLicense(activity) }
         }
     }
 

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/dialogs/AppUpdateDialog.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/dialogs/AppUpdateDialog.kt
@@ -1,0 +1,36 @@
+// FILE: app/src/main/java/com/hereliesaz/cuedetat/ui/composables/dialogs/AppUpdateDialog.kt
+
+package com.hereliesaz.cuedetat.ui.composables.dialogs
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+
+/**
+ * One-tap update popup for the FOSS build. Tapping "Download & install"
+ * downloads the newest release APK and launches the system installer (Android
+ * always shows its own confirm step — full silent install isn't possible for a
+ * normally-installed app).
+ */
+@Composable
+fun AppUpdateDialog(
+    versionName: String,
+    onInstall: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Update available") },
+        text = { Text("Version $versionName is ready. Download and install it now?") },
+        confirmButton = {
+            TextButton(onClick = {
+                onInstall()
+                onDismiss()
+            }) { Text("Download & install") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Later") }
+        },
+    )
+}

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/overlays/TutorialOverlay.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/overlays/TutorialOverlay.kt
@@ -298,6 +298,19 @@ fun TutorialOverlay(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
+                // Always-available dismiss. The tutorial must be escapable at any
+                // step and in any tutorial type, not only on the final "Done" step.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    TextButton(onClick = { onEvent(MainScreenEvent.EndTutorial) }) {
+                        Text(
+                            text = "${stringResource(id = R.string.tutorial_dismiss)}  ✕",
+                            style = MaterialTheme.typography.labelMedium
+                        )
+                    }
+                }
                 Text(
                     text = tutorialSteps.getOrNull(uiState.currentTutorialStep)
                         ?: stringResource(id = R.string.tutorial_over),

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallSheet.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallSheet.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
@@ -41,6 +42,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.hereliesaz.cuedetat.R
 import com.hereliesaz.cuedetat.billing.PaywallTrigger
 import com.hereliesaz.cuedetat.billing.ProductDetailsState
 import com.hereliesaz.cuedetat.billing.isPlausibleTesterEmail
@@ -97,7 +99,27 @@ fun PaywallSheet(
                         "feel marginally less bad about yourself.",
                 style = MaterialTheme.typography.bodyMedium
             )
+            Spacer(Modifier.height(16.dp))
+            // A note to whoever's reading this. Same sentiment as the old
+            // "free trial, cancel anytime" copy — honest about why it costs money.
+            Text(
+                text = stringResource(id = R.string.paywall_personal_note),
+                style = MaterialTheme.typography.bodySmall
+            )
             Spacer(Modifier.height(24.dp))
+
+            if (uiState.trialAvailable) {
+                Button(
+                    onClick = { viewModel.startTrial() },
+                    modifier = Modifier.fillMaxWidth()
+                ) { Text(stringResource(id = R.string.paywall_trial_cta)) }
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    stringResource(id = R.string.paywall_trial_subtitle),
+                    style = MaterialTheme.typography.bodySmall
+                )
+                Spacer(Modifier.height(16.dp))
+            }
 
             when (val pd = uiState.productDetails) {
                 is ProductDetailsState.Loading -> CircularProgressIndicator()

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/paywall/PaywallViewModel.kt
@@ -40,6 +40,7 @@ class PaywallViewModel @Inject constructor(
         get() = repository.isCredentialManagerAvailable
 
     init {
+        _uiState.value = _uiState.value.copy(trialAvailable = repository.isExpertTrialAvailable)
         viewModelScope.launch {
             repository.productDetails().collect { state ->
                 _uiState.value = _uiState.value.copy(productDetails = state)
@@ -80,6 +81,18 @@ class PaywallViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching { repository.restorePurchases() }
             refreshDiagnostics()
+        }
+    }
+
+    /**
+     * Start the one-time, one-hour Expert preview. On success the entitlement
+     * flow flips active and the existing collector above auto-enters Expert and
+     * dismisses the sheet — same path as a completed purchase.
+     */
+    fun startTrial() {
+        viewModelScope.launch {
+            runCatching { repository.startExpertTrial() }
+            _uiState.value = _uiState.value.copy(trialAvailable = repository.isExpertTrialAvailable)
         }
     }
 
@@ -146,4 +159,5 @@ data class PaywallUiState(
     val testerLicenseOutcome: TesterLicenseResult? = null,
     val diagnostics: EntitlementDiagnostics = EntitlementDiagnostics(emptyList(), "not loaded", false),
     val showDiagnostics: Boolean = false,
+    val trialAvailable: Boolean = false,
 )

--- a/app/src/main/java/com/hereliesaz/cuedetat/update/AppUpdater.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/update/AppUpdater.kt
@@ -1,0 +1,72 @@
+// FILE: app/src/main/java/com/hereliesaz/cuedetat/update/AppUpdater.kt
+
+package com.hereliesaz.cuedetat.update
+
+import android.app.Activity
+
+/**
+ * Details of an available update, surfaced to the UI so it can offer a
+ * one-tap download + install.
+ */
+data class UpdateInfo(
+    /** The release version, e.g. "1.9.0". */
+    val versionName: String,
+    /** Direct APK download URL, or null if the release has no APK asset. */
+    val apkUrl: String?,
+    /** The GitHub release page, used as a fallback when [apkUrl] is null. */
+    val releaseUrl: String?,
+)
+
+/**
+ * Flavor-specific self-update.
+ *
+ *  - **foss**: checks GitHub releases and can sideload the new APK via the
+ *    system installer (the only kind of "auto-update" Android allows a
+ *    normally-installed app).
+ *  - **play**: no-op. Google Play owns updates for store installs, and
+ *    self-updating APKs violate Play policy.
+ */
+interface AppUpdater {
+
+    /** True only in flavors that can self-update (FOSS). */
+    val isSupported: Boolean get() = false
+
+    /**
+     * Returns [UpdateInfo] when a newer release than the running build is
+     * available, else null. No-op (null) in the Play flavor.
+     */
+    suspend fun checkForUpdate(): UpdateInfo? = null
+
+    /**
+     * Download the release APK and launch the system installer. No-op in Play.
+     * Must be called with an [Activity] so the install prompt and any
+     * "allow from this source" settings redirect have a UI host.
+     */
+    suspend fun downloadAndInstall(activity: Activity, info: UpdateInfo) {}
+}
+
+/**
+ * Compares dotted version strings, ignoring a leading "v" and any non-numeric
+ * suffix (e.g. the FOSS build's "-foss"). Returns true when [latestTag] is
+ * strictly newer than [current].
+ */
+fun isNewerVersion(latestTag: String, current: String): Boolean {
+    fun parse(v: String): List<Int> =
+        v.trim()
+            .removePrefix("v")
+            .removePrefix("V")
+            .takeWhile { it.isDigit() || it == '.' }
+            .split('.')
+            .mapNotNull { it.toIntOrNull() }
+
+    val a = parse(latestTag)
+    val b = parse(current)
+    if (a.isEmpty()) return false
+    val n = maxOf(a.size, b.size)
+    for (i in 0 until n) {
+        val x = a.getOrElse(i) { 0 }
+        val y = b.getOrElse(i) { 0 }
+        if (x != y) return x > y
+    }
+    return false
+}

--- a/app/src/main/java/com/hereliesaz/cuedetat/view/PaintCache.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/view/PaintCache.kt
@@ -124,6 +124,14 @@ class PaintCache {
     val glowPaint = Paint(Paint.ANTI_ALIAS_FLAG)
 
     /**
+     * Reusable paint for the hardware-accelerated RadialGradient glow halo
+     * (see [com.hereliesaz.cuedetat.view.renderer.util.drawGlowCircle]). A
+     * fresh shader is assigned per draw; the Paint itself is reused to avoid
+     * per-frame allocation.
+     */
+    val glowHaloPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+
+    /**
      * Configures and returns the reused [glowPaint] object for the current frame.
      *
      * Handles the "Glow Stick" feature logic:

--- a/app/src/main/java/com/hereliesaz/cuedetat/view/renderer/ball/BallRenderer.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/view/renderer/ball/BallRenderer.kt
@@ -27,7 +27,7 @@ import com.hereliesaz.cuedetat.view.config.ui.LabelConfig
 import com.hereliesaz.cuedetat.view.model.LogicalCircular
 import com.hereliesaz.cuedetat.view.renderer.text.BallTextRenderer
 import com.hereliesaz.cuedetat.view.renderer.util.DrawingUtils
-import com.hereliesaz.cuedetat.view.renderer.util.createGlowPaint
+import com.hereliesaz.cuedetat.view.renderer.util.drawGlowCircle
 import com.hereliesaz.cuedetat.view.renderer.warpedBy
 import kotlin.math.hypot
 import androidx.core.graphics.withMatrix
@@ -155,7 +155,6 @@ class BallRenderer {
             val mappedEdge = DrawingUtils.mapPoint(PointF(drawCenter.x + ball.radius, drawCenter.y), logicalBallMatrix)
             val exactScreenRadius = hypot((mappedEdge.x - logicalScreenPos.x).toDouble(), (mappedEdge.y - logicalScreenPos.y).toDouble()).toFloat()
 
-            val glowPaint = createGlowPaint(config.glowColor, config.glowWidth, state, paints, blurType = android.graphics.BlurMaskFilter.Blur.OUTER)
             val strokePaint = beginnerCircleStroke.apply {
                 reset()
                 isAntiAlias = true
@@ -166,7 +165,7 @@ class BallRenderer {
             }
             val screenInnerRadius = exactScreenRadius - (14f / 2f)
 
-            canvas.drawCircle(logicalScreenPos.x, logicalScreenPos.y, exactScreenRadius, glowPaint)
+            drawGlowCircle(canvas, logicalScreenPos.x, logicalScreenPos.y, exactScreenRadius, config.glowColor, state, paints)
             canvas.drawCircle(logicalScreenPos.x, logicalScreenPos.y, screenInnerRadius, strokePaint)
         }
     }
@@ -387,12 +386,11 @@ class BallRenderer {
                 alpha = (config.opacity * 255).toInt()
                 style = Paint.Style.STROKE
             }
-            val glowPaint = createGlowPaint(config.glowColor, config.glowWidth, state, paints, blurType = android.graphics.BlurMaskFilter.Blur.OUTER)
             val screenInnerRadius = exactScreenRadius - (14f / 2f)
 
             // Order for Beginner: Bubble fill is the LOWEST.
             canvas.drawCircle(bubbleCenter.x, bubbleCenter.y, exactScreenRadius, translucentFillPaint)
-            canvas.drawCircle(logicalScreenPos.x, logicalScreenPos.y, exactScreenRadius, glowPaint)
+            drawGlowCircle(canvas, logicalScreenPos.x, logicalScreenPos.y, exactScreenRadius, config.glowColor, state, paints)
             canvas.drawCircle(logicalScreenPos.x, logicalScreenPos.y, screenInnerRadius, strokePaint)
 
         } else {
@@ -421,12 +419,7 @@ class BallRenderer {
                 alpha = (config.opacity * 255).toInt()
                 style = Paint.Style.STROKE
             }
-            val glowPaint = createGlowPaint(
-                baseGlowColor = if (isWarning) Color(paints.warningPaint.color) else config.glowColor,
-                baseGlowWidth = config.glowWidth,
-                state = state,
-                paints = paints
-            )
+            val glowColor = if (isWarning) Color(paints.warningPaint.color) else config.glowColor
 
             // Draw "On-Table" logical outline
             canvas.withMatrix(positionMatrix) {
@@ -434,7 +427,7 @@ class BallRenderer {
             }
 
             // Draw "Lifted" visual body
-            canvas.drawCircle(logicalScreenPos.x, yPosLifted, radiusInfo.radius, glowPaint)
+            drawGlowCircle(canvas, logicalScreenPos.x, yPosLifted, radiusInfo.radius, glowColor, state, paints)
             canvas.drawCircle(logicalScreenPos.x, yPosLifted, radiusInfo.radius, strokePaint)
         }
     }

--- a/app/src/main/java/com/hereliesaz/cuedetat/view/renderer/util/PaintUtils.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/view/renderer/util/PaintUtils.kt
@@ -3,11 +3,82 @@
 package com.hereliesaz.cuedetat.view.renderer.util
 
 import android.graphics.BlurMaskFilter
+import android.graphics.Canvas
+import android.graphics.Color as AndroidColor
 import android.graphics.Paint
+import android.graphics.RadialGradient
+import android.graphics.Shader
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import com.hereliesaz.cuedetat.domain.CueDetatState
+import com.hereliesaz.cuedetat.view.PaintCache
 import kotlin.math.abs
+
+/**
+ * Draws a soft glow halo around a ball ring of [ringRadius] at ([cx], [cy]),
+ * using a hardware-accelerated [RadialGradient] instead of a
+ * [BlurMaskFilter].
+ *
+ * Why: the overlay is drawn into Compose's hardware-accelerated canvas. A
+ * `BlurMaskFilter` is not supported in hardware, so each blurred circle forces
+ * a software-rendered intermediate whose cost scales with the drawn circle's
+ * AREA. As the user zooms in, on-screen balls grow and the per-frame blur cost
+ * grows quadratically — the source of the "laggier the closer the balls" jank
+ * in dynamic basic mode. A RadialGradient stays on the GPU and is effectively
+ * free at any zoom.
+ *
+ * The halo peaks at the ring and fades to transparent both inward and outward,
+ * with the spread scaled to the ring so the glow looks consistent at every
+ * zoom level (a fixed-pixel blur, by contrast, vanished when zoomed in).
+ */
+fun drawGlowCircle(
+    canvas: Canvas,
+    cx: Float,
+    cy: Float,
+    ringRadius: Float,
+    baseGlowColor: Color,
+    state: CueDetatState,
+    paints: PaintCache,
+) {
+    if (ringRadius <= 0f) return
+
+    val glowValue = state.glowStickValue
+    val colorInt: Int
+    val peakAlpha: Int
+    if (abs(glowValue) > 0.05f) {
+        // Glow Stick override: positive = white, negative = black.
+        peakAlpha = (abs(glowValue) * 255).toInt().coerceIn(0, 255)
+        colorInt = if (glowValue > 0) AndroidColor.WHITE else AndroidColor.BLACK
+    } else {
+        colorInt = baseGlowColor.toArgb()
+        peakAlpha = (baseGlowColor.alpha * 255 * 0.7f).toInt().coerceIn(0, 255)
+    }
+    if (peakAlpha == 0) return
+
+    // Spread scales with the ring so the glow is proportional at any zoom.
+    val spread = (ringRadius * 0.35f).coerceAtLeast(6f)
+    val outer = ringRadius + spread
+
+    val peak = (colorInt and 0x00FFFFFF) or (peakAlpha shl 24)
+    val transparent = colorInt and 0x00FFFFFF // alpha 0
+
+    val innerStop = ((ringRadius - spread) / outer).coerceIn(0f, 0.98f)
+    val ringStop = (ringRadius / outer).coerceIn(innerStop + 0.001f, 0.999f)
+
+    val shader = RadialGradient(
+        cx, cy, outer,
+        intArrayOf(transparent, peak, transparent),
+        floatArrayOf(innerStop, ringStop, 1f),
+        Shader.TileMode.CLAMP,
+    )
+    val paint = paints.glowHaloPaint.apply {
+        this.shader = shader
+        style = Paint.Style.FILL
+        isAntiAlias = true
+    }
+    canvas.drawCircle(cx, cy, outer, paint)
+    paint.shader = null
+}
 
 /**
  * Creates and configures a [Paint] object for glow effects.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
     <string name="tutorial_next">Next</string>
     <string name="tutorial_skip">Skip</string>
     <string name="tutorial_done">Done</string>
+    <string name="tutorial_dismiss">Skip tutorial</string>
 
     <string-array name="tutorial_dynamic_non_ar">
         <item>Look at you, breaking free. This is Dynamic Mode. The world is your table.</item>
@@ -124,4 +125,9 @@
     <string name="label_ghost_cue_ball_instruction">Aim the cue ball at\nthe center of the blue circle.</string>
     <string name="label_ghost_cue_ball">Ghost Cue Ball</string>
     <string name="label_obstacle">Obstacle %1$d</string>
+
+    <!-- Paywall -->
+    <string name="paywall_personal_note">Look — it\'s just me building this, and the lights cost money. Expert Mode is how Cue D\'état keeps existing. If you can spare it, the one-time unlock below funds the next feature. If you can\'t, the whole thing is free on GitHub, no hard feelings. Either way, thanks for actually using the thing I made.</string>
+    <string name="paywall_trial_cta">Try Expert free for 1 hour</string>
+    <string name="paywall_trial_subtitle">One-time, one-hour preview. No card, no strings — see what it does, then decide.</string>
 </resources>

--- a/app/src/play/java/com/hereliesaz/cuedetat/billing/PlayBillingEntitlementRepository.kt
+++ b/app/src/play/java/com/hereliesaz/cuedetat/billing/PlayBillingEntitlementRepository.kt
@@ -6,10 +6,12 @@ import android.app.Activity
 import android.util.Log
 import com.hereliesaz.cuedetat.data.IntegrityRepository
 import com.hereliesaz.cuedetat.data.IntegrityResult
+import com.hereliesaz.cuedetat.data.UserPreferencesRepository
 import com.android.billingclient.api.ProductDetails
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,9 +42,17 @@ class PlayBillingEntitlementRepository @Inject constructor(
     private val testLicenseStore: TestLicenseStore,
     private val integrityRepository: IntegrityRepository,
     private val googleAccountResolver: GoogleAccountResolver,
+    private val userPreferencesRepository: UserPreferencesRepository,
 ) : EntitlementRepository {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /** Epoch millis the Expert trial was started; 0 = never used. */
+    @Volatile
+    private var trialStartedAt: Long = 0L
+
+    private fun trialActiveNow(now: Long): Boolean =
+        trialStartedAt > 0L && now < trialStartedAt + TRIAL_DURATION_MS
 
     /** Last computed Play entitlement. Combined with the tester license to
      *  produce the public `entitlement` value. */
@@ -76,7 +86,12 @@ class PlayBillingEntitlementRepository @Inject constructor(
             val cached = runCatching { cacheStore.read() }.getOrDefault(Entitlement.NONE)
             playEntitlement.value = cached
             Log.i(TAG, "init: cached entitlement active=${cached.active} source=${cached.source}")
+
+            // Restore any in-flight Expert trial so a still-valid preview keeps
+            // working across process restarts, and schedule its expiry.
+            trialStartedAt = runCatching { userPreferencesRepository.readExpertTrialStartedAt() }.getOrDefault(0L)
             republish()
+            if (trialActiveNow(System.currentTimeMillis())) scheduleTrialExpiry()
 
             // 2. Restore any previously-verified tester license. If the
             //    allowlist no longer contains the stored hash (group membership
@@ -276,17 +291,66 @@ class PlayBillingEntitlementRepository @Inject constructor(
         val play = playEntitlement.value
         val tester = verifiedTesterHash
         val genuine = isDeviceGenuine
-        _entitlement.value = if (tester != null) {
-            Entitlement(
+        val now = System.currentTimeMillis()
+        _entitlement.value = when {
+            tester != null -> Entitlement(
                 active = true,
                 source = EntitlementSource.TESTER_LICENSE,
                 expiresAtMillis = null,
                 productId = play.productId,
-                lastVerifiedAtMillis = System.currentTimeMillis(),
+                lastVerifiedAtMillis = now,
                 isDeviceGenuine = genuine
             )
-        } else {
-            play.copy(isDeviceGenuine = genuine)
+            play.active -> play.copy(isDeviceGenuine = genuine)
+            trialActiveNow(now) -> Entitlement(
+                active = true,
+                source = EntitlementSource.TRIAL,
+                expiresAtMillis = trialStartedAt + TRIAL_DURATION_MS,
+                productId = play.productId,
+                lastVerifiedAtMillis = now,
+                isDeviceGenuine = genuine
+            )
+            else -> play.copy(isDeviceGenuine = genuine)
+        }
+    }
+
+    override val isExpertTrialAvailable: Boolean
+        get() = trialStartedAt == 0L
+
+    override suspend fun startExpertTrial(): Boolean {
+        if (trialStartedAt != 0L) {
+            Log.i(TAG, "startExpertTrial: trial already used")
+            return false
+        }
+        if (_entitlement.value.active) {
+            Log.i(TAG, "startExpertTrial: already entitled; not starting trial")
+            return false
+        }
+        val now = System.currentTimeMillis()
+        trialStartedAt = now
+        runCatching { userPreferencesRepository.setExpertTrialStartedAt(now) }
+        Log.i(TAG, "startExpertTrial: started 1h Expert preview")
+        republish()
+        scheduleTrialExpiry()
+        return true
+    }
+
+    /**
+     * Re-publishes the entitlement once the active trial elapses, so the app
+     * downgrades EXPERT→BEGINNER on time even if it stays in the foreground.
+     * Resumes/refreshes also re-evaluate via [republish], so this is a
+     * best-effort timer, not the sole expiry mechanism.
+     */
+    private fun scheduleTrialExpiry() {
+        val remaining = (trialStartedAt + TRIAL_DURATION_MS) - System.currentTimeMillis()
+        if (remaining <= 0L) {
+            republish()
+            return
+        }
+        scope.launch {
+            delay(remaining)
+            Log.i(TAG, "Expert trial expired; revoking")
+            republish()
         }
     }
 
@@ -319,5 +383,8 @@ class PlayBillingEntitlementRepository @Inject constructor(
 
     companion object {
         private const val TAG = "PlayBillingEntitlement"
+
+        /** One-time Expert preview length: one hour. */
+        private const val TRIAL_DURATION_MS = 60L * 60L * 1000L
     }
 }

--- a/app/src/play/java/com/hereliesaz/cuedetat/di/PlayUpdateModule.kt
+++ b/app/src/play/java/com/hereliesaz/cuedetat/di/PlayUpdateModule.kt
@@ -1,0 +1,21 @@
+// FILE: app/src/play/java/com/hereliesaz/cuedetat/di/PlayUpdateModule.kt
+
+package com.hereliesaz.cuedetat.di
+
+import com.hereliesaz.cuedetat.update.AppUpdater
+import com.hereliesaz.cuedetat.update.PlayAppUpdater
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/** Binds the no-op updater for Play builds (store-managed updates). */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class PlayUpdateModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindAppUpdater(impl: PlayAppUpdater): AppUpdater
+}

--- a/app/src/play/java/com/hereliesaz/cuedetat/update/PlayAppUpdater.kt
+++ b/app/src/play/java/com/hereliesaz/cuedetat/update/PlayAppUpdater.kt
@@ -1,0 +1,14 @@
+// FILE: app/src/play/java/com/hereliesaz/cuedetat/update/PlayAppUpdater.kt
+
+package com.hereliesaz.cuedetat.update
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Play-flavor [AppUpdater]: a no-op. Google Play manages updates for store
+ * installs, and a self-updating APK would violate Play policy. All defaults
+ * apply (not supported, no update, no install).
+ */
+@Singleton
+class PlayAppUpdater @Inject constructor() : AppUpdater


### PR DESCRIPTION
Addresses the five reported issues. Plan: `how-exactly-do-i-fancy-gray`.

## 1. Tester on the list but Expert never unlocks
The silent tester-license resolve only ran when the **paywall sheet was opened** — an allowlisted tester who never opened it never got unlocked. Now `MainActivity.onResume` calls `MainViewModel.attemptTesterAutoUnlock(activity)` (one-shot, self-guarded, no prompt), which runs `silentlyResolveTesterLicense`. Expert "just works" for an authorized tester on the allowlist.

> ⚠️ **Verify first via the paywall's "Show billing diagnostics":** if it shows *"Allowlist baked into APK: no"*, the build wasn't assembled with the tester allowlist and the fix is CI secrets (`GG_LINK`/`GG_SESSION` on the play-release pipeline), not app code.

## 2. Missing paywall message + 1-hour trial
- Re-added a personal note on the paywall in the sentiment of the old subscription copy (`R.string.paywall_personal_note`).
- Added a **one-time, one-hour Expert preview**: new `EntitlementSource.TRIAL`, trial-start persisted in `UserPreferencesRepository`, granted via `EntitlementRepository.startExpertTrial()`, folded into the Play repo's `republish()`, and auto-expiring (timer + re-evaluation on resume/refresh; existing `EntitlementReducer` downgrades EXPERT→BEGINNER when it lapses). Button hidden once consumed. FOSS is a no-op (already entitled).

## 3. Zoom lag in dynamic basic mode
Root cause: the ball glow used `BlurMaskFilter`, which isn't hardware-accelerated — on Compose's hardware canvas it forces a software-rendered layer whose cost scales with the drawn circle's **area**. Zooming in grows the on-screen ball, so per-frame cost grew quadratically. Replaced with a hardware-accelerated `RadialGradient` halo (`drawGlowCircle`) for the three ball-circle glows; line/rail glows are untouched.

## 4. ML model / bounding boxes
The pipeline is already wired (model loads, `detectPool` runs, `drawBoundingBoxes` runs in dynamic beginner, camera is LITE_AR there). Hardened the most likely failure mode: box parsing now **auto-detects normalized vs input-pixel coordinates** (a pixel-coordinate export would otherwise draw boxes ~640× too large and off-screen → "does nothing"). Added debug-only logging of raw model output (tensor shape, sample rows, kept-count) for on-device diagnosis.

> The box **axis ordering** (`[ymin,xmin,ymax,xmax]`, matching TFLite_Detection_PostProcess) is left as-is; confirm against the logged rows on-device and flip if the export differs.

## 5. FOSS auto-update
- `GithubApi`/`GithubRepository` extended to return release assets + page URL.
- New flavor-bound `AppUpdater`: FOSS implementation checks GitHub releases on launch and, on confirm, downloads the APK and launches the system installer; Play is a no-op (store-managed).
- One-tap "Update available" popup (`AppUpdateDialog`).
- `REQUEST_INSTALL_PACKAGES` + a `FileProvider` are isolated to `src/foss/AndroidManifest.xml` so the Play APK is unaffected (full silent install isn't possible for a sideloaded app — Android always shows its installer prompt).

## Verification needed (couldn't build here — no Android SDK in this env)
- `./gradlew :app:assemblePlayDebug :app:assembleFossDebug` and `:app:testPlayDebugUnitTest`.
- On device:
  - Dynamic basic mode pinch-zoom: no frame drops.
  - Tutorial: "Skip tutorial" dismisses at any step.
  - ML: boxes appear on every ball; check logcat `MergedTFLiteDetector` for raw rows.
  - Tester: Expert unlocks on launch for an allowlisted account; diagnostics shows allowlist = yes.
  - Trial: "Try Expert free for 1 hour" enters Expert, then downgrades after an hour; button gone after use.
  - FOSS: with a lower local versionName, the update popup appears and the installer launches.

---
_Generated by [Claude Code](https://claude.ai/code/session_0156VfDiuomuRA2yjwchfWX5)_