### PR TITLE
Expert mode: crosshair pocket capture + glasses connection feedback

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/data/MetaWearableRepository.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/MetaWearableRepository.kt
@@ -23,27 +23,48 @@ import java.io.ByteArrayOutputStream
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Coarse connection state for the Meta glasses stream, surfaced to the UI so the
+ * "glasses" toggle gives visible feedback instead of failing silently.
+ */
+enum class MetaConnectionStatus {
+    IDLE,
+    CONNECTING,
+    STREAMING,
+    NO_DEVICE,
+    ERROR
+}
+
 @Singleton
 class MetaWearableRepository @Inject constructor(
     @param:ApplicationContext private val context: Context,
 ) {
     private val tag = "MetaWearableRepo"
-    
+
     private var currentSession: Session? = null
     private var currentStream: Stream? = null
     private var sessionJob: Job? = null
-    
+
     private val _videoFrame = MutableStateFlow<Bitmap?>(null)
     val videoFrame = _videoFrame.asStateFlow()
-    
+
     private val _isStreaming = MutableStateFlow(false)
     val isStreaming = _isStreaming.asStateFlow()
+
+    private val _connectionStatus = MutableStateFlow(MetaConnectionStatus.IDLE)
+    val connectionStatus = _connectionStatus.asStateFlow()
+
+    /** Human-readable detail of the most recent failure, for diagnostics. */
+    private val _lastError = MutableStateFlow<String?>(null)
+    val lastError = _lastError.asStateFlow()
 
     private val scope = CoroutineScope(Dispatchers.Default)
 
     fun startStreaming() {
         if (_isStreaming.value) return
-        
+
+        _connectionStatus.value = MetaConnectionStatus.CONNECTING
+        _lastError.value = null
         scope.launch {
             Log.d(tag, "Starting Meta glasses session...")
             try {
@@ -60,18 +81,27 @@ class MetaWearableRepository @Inject constructor(
                         currentStream = stream
                         stream.start()
                         _isStreaming.value = true
+                        _connectionStatus.value = MetaConnectionStatus.STREAMING
                         observeStream(stream)
                         Log.d(tag, "Meta stream started successfully")
                     }.onFailure { error ->
                         Log.e(tag, "Failed to add stream: $error")
+                        _lastError.value = "Stream error: $error"
+                        _connectionStatus.value = MetaConnectionStatus.ERROR
                         stopStreaming()
                     }
                 }.onFailure { error ->
+                    // No paired/available device is the common case here; surface it
+                    // distinctly so the UI can tell the user to pair their glasses.
                     Log.e(tag, "Failed to create session: $error")
+                    _lastError.value = "Session error: $error"
+                    _connectionStatus.value = MetaConnectionStatus.NO_DEVICE
                     _isStreaming.value = false
                 }
             } catch (e: Exception) {
                 Log.e(tag, "Unexpected error in startStreaming", e)
+                _lastError.value = e.message ?: e.toString()
+                _connectionStatus.value = MetaConnectionStatus.ERROR
                 _isStreaming.value = false
                 stopStreaming()
             }
@@ -105,6 +135,12 @@ class MetaWearableRepository @Inject constructor(
         currentSession = null
         _isStreaming.value = false
         _videoFrame.value = null
+        // Preserve a freshly-set failure status; only reset to IDLE on a clean stop.
+        if (_connectionStatus.value == MetaConnectionStatus.STREAMING ||
+            _connectionStatus.value == MetaConnectionStatus.CONNECTING
+        ) {
+            _connectionStatus.value = MetaConnectionStatus.IDLE
+        }
     }
 
     private fun VideoFrame.toBitmap(): Bitmap? {

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/MetaWearableBackground.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/MetaWearableBackground.kt
@@ -1,15 +1,25 @@
 package com.hereliesaz.cuedetat.ui.composables
 
-import android.graphics.Bitmap
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.cuedetat.data.MetaConnectionStatus
 import com.hereliesaz.cuedetat.data.MetaWearableRepository
 
 @Composable
@@ -18,15 +28,45 @@ fun MetaWearableBackground(
     metaWearableRepository: MetaWearableRepository
 ) {
     val videoFrame by metaWearableRepository.videoFrame.collectAsState()
+    val status by metaWearableRepository.connectionStatus.collectAsState()
+    val lastError by metaWearableRepository.lastError.collectAsState()
 
     Box(modifier = modifier.fillMaxSize()) {
-        videoFrame?.let { bitmap ->
+        val frame = videoFrame
+        if (frame != null) {
             Image(
-                bitmap = bitmap.asImageBitmap(),
+                bitmap = frame.asImageBitmap(),
                 contentDescription = "Meta Glasses Stream",
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop
             )
+        } else {
+            // No frame yet — give the user visible feedback instead of a blank screen
+            // so the "glasses" toggle never appears to do nothing.
+            val message = when (status) {
+                MetaConnectionStatus.CONNECTING -> "Connecting to glasses…"
+                MetaConnectionStatus.STREAMING -> "Waiting for video…"
+                MetaConnectionStatus.NO_DEVICE ->
+                    "No Meta glasses found.\nPair them in the Meta AI app, then tap glasses again."
+                MetaConnectionStatus.ERROR ->
+                    "Couldn't connect to glasses.${lastError?.let { "\n$it" } ?: ""}"
+                MetaConnectionStatus.IDLE -> "Starting glasses…"
+            }
+            Box(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(32.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(Color.Black.copy(alpha = 0.7f))
+                    .padding(horizontal = 24.dp, vertical = 16.dp)
+            ) {
+                Text(
+                    text = message,
+                    color = Color.White,
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanScreen.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanScreen.kt
@@ -21,20 +21,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.clickable
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -62,7 +56,6 @@ import com.hereliesaz.cuedetat.domain.CueDetatState
 import com.hereliesaz.cuedetat.domain.MainScreenEvent
 import com.hereliesaz.cuedetat.domain.PocketId
 import kotlinx.coroutines.delay
-import kotlin.math.roundToInt
 import android.graphics.PointF as AndroidPointF
 
 /**
@@ -85,6 +78,8 @@ fun TableScanScreen(
     var showGreenFlash by remember { mutableStateOf(false) }
     var isCapturingPocket by remember { mutableStateOf(false) }
     var pocketCaptureCount by remember { mutableStateOf(0) }
+    var isCapturingCorner by remember { mutableStateOf(false) }
+    var cornerCaptureCount by remember { mutableStateOf(0) }
 
     // Captured felt color from the ViewModel (non-null once captureFeltAndComplete fires).
     val capturedHsv by viewModel.capturedFeltHsv.collectAsState()
@@ -118,10 +113,23 @@ fun TableScanScreen(
         label = "pocketMagnifyCircle"
     )
 
+    val cornerCircleSize by animateDpAsState(
+        targetValue = if (isCapturingCorner) 240.dp else 120.dp,
+        animationSpec = tween(durationMillis = 400),
+        label = "cornerMagnifyCircle"
+    )
+
     LaunchedEffect(pocketCaptureCount) {
         if (pocketCaptureCount > 0) {
             delay(600L)
             isCapturingPocket = false
+        }
+    }
+
+    LaunchedEffect(cornerCaptureCount) {
+        if (cornerCaptureCount > 0) {
+            delay(600L)
+            isCapturingCorner = false
         }
     }
 
@@ -239,7 +247,7 @@ fun TableScanScreen(
         val showReticle = when (scanStep) {
             ScanStep.FELT_CAPTURE -> capturedHsv == null
             ScanStep.POCKET_GUIDE -> true
-            ScanStep.CORNER_QUAD -> false
+            ScanStep.CORNER_QUAD -> true
             ScanStep.AUTO_READY -> false
         }
         if (showReticle) {
@@ -285,70 +293,103 @@ fun TableScanScreen(
                         }
                     }
                 }
-            }
-        }
-
-        // Corner-quad: full-screen tap target + draggable corner handles.
-        if (scanStep == ScanStep.CORNER_QUAD) {
-            val density = LocalDensity.current
-            val handleDp = 32.dp
-            val handlePx = with(density) { handleDp.toPx() }
-
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .pointerInput(cornerTaps.size) {
-                        detectTapGestures { offset ->
-                            if (viewModel.cornerTaps.value.size < 4) {
-                                viewModel.onCornerTap(AndroidPointF(offset.x, offset.y))
-                            }
-                        }
-                    }
-            )
-
-            // Connecting lines between placed corners (light visual guide).
-            if (cornerTaps.isNotEmpty()) {
-                Canvas(modifier = Modifier.fillMaxSize()) {
-                    val ordered = cornerTaps
-                    for (i in ordered.indices) {
-                        val a = ordered[i]
-                        val b = ordered[(i + 1) % ordered.size]
-                        if (ordered.size > 1 && i < ordered.size - 1 || ordered.size == 4) {
-                            drawLine(
-                                color = Color.Yellow.copy(alpha = 0.4f),
-                                start = Offset(a.x, a.y),
-                                end = Offset(b.x, b.y),
-                                strokeWidth = 2.dp.toPx()
+            } else if (scanStep == ScanStep.CORNER_QUAD) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(cornerCircleSize)
+                        .clip(CircleShape)
+                        .background(Color.Black.copy(alpha = 0.2f))
+                        .border(2.dp, Color.White.copy(alpha = 0.8f), CircleShape)
+                ) {
+                    if (!isCapturingCorner) {
+                        val crosshairColor = if (cornerTaps.size >= 4) Color.Green else Color.White
+                        Canvas(modifier = Modifier.fillMaxSize()) {
+                            drawCircle(
+                                color = crosshairColor.copy(alpha = 0.3f),
+                                radius = size.minDimension / 2,
+                                style = Stroke(width = 1.dp.toPx())
                             )
+                            // Crosshair lines for precise aiming at the pocket.
+                            drawLine(
+                                color = crosshairColor,
+                                start = Offset(center.x - 12.dp.toPx(), center.y),
+                                end = Offset(center.x + 12.dp.toPx(), center.y),
+                                strokeWidth = 1.5.dp.toPx()
+                            )
+                            drawLine(
+                                color = crosshairColor,
+                                start = Offset(center.x, center.y - 12.dp.toPx()),
+                                end = Offset(center.x, center.y + 12.dp.toPx()),
+                                strokeWidth = 1.5.dp.toPx()
+                            )
+                            drawCircle(color = crosshairColor, radius = 2.dp.toPx(), center = center)
                         }
                     }
                 }
             }
+        }
 
-            cornerTaps.forEachIndexed { idx, pt ->
-                Box(
-                    modifier = Modifier
-                        .offset {
-                            IntOffset(
-                                (pt.x - handlePx / 2f).roundToInt(),
-                                (pt.y - handlePx / 2f).roundToInt()
-                            )
-                        }
-                        .size(handleDp)
-                        .clip(CircleShape)
-                        .background(Color.Yellow.copy(alpha = 0.5f))
-                        .border(2.dp, Color.White, CircleShape)
-                        .pointerInput(idx) {
-                            detectDragGestures { change, drag ->
-                                change.consume()
-                                val current = viewModel.cornerTaps.value.getOrNull(idx) ?: return@detectDragGestures
-                                viewModel.onCornerDrag(
-                                    idx,
-                                    AndroidPointF(current.x + drag.x, current.y + drag.y)
-                                )
-                            }
-                        }
-                )
+        // Corner-quad polygon overlay.
+        //
+        // The captured corners are logical-space points anchored to the table plane.
+        // We project them back to screen space through the live pitch matrix every
+        // frame, so each marked pocket stays glued to its spot as the device tilts.
+        // A trailing line runs from the last marked pocket to the centre crosshair,
+        // so the user visibly "draws" the table polygon as they capture each corner.
+        if (scanStep == ScanStep.CORNER_QUAD) {
+            val pitchMatrix = uiState.pitchMatrix
+            // Project a logical point to screen pixels via the current pitch matrix.
+            fun project(pt: AndroidPointF): Offset? {
+                pitchMatrix ?: return null
+                val arr = floatArrayOf(pt.x, pt.y)
+                pitchMatrix.mapPoints(arr)
+                return Offset(arr[0], arr[1])
+            }
+
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                val projected = cornerTaps.mapNotNull { project(it) }
+                val crosshair = Offset(size.width / 2f, size.height / 2f)
+                val isClosed = cornerTaps.size >= 4
+
+                // Polygon edges between consecutive captured corners.
+                for (i in 0 until projected.size - 1) {
+                    drawLine(
+                        color = Color.Yellow.copy(alpha = 0.6f),
+                        start = projected[i],
+                        end = projected[i + 1],
+                        strokeWidth = 2.dp.toPx()
+                    )
+                }
+
+                if (isClosed && projected.size == 4) {
+                    // Close the quad: last corner back to the first.
+                    drawLine(
+                        color = Color.Green.copy(alpha = 0.7f),
+                        start = projected[3],
+                        end = projected[0],
+                        strokeWidth = 2.dp.toPx()
+                    )
+                } else if (projected.isNotEmpty()) {
+                    // Trailing rubber-band line from the last marked pocket to the crosshair.
+                    drawLine(
+                        color = Color.White.copy(alpha = 0.5f),
+                        start = projected.last(),
+                        end = crosshair,
+                        strokeWidth = 2.dp.toPx()
+                    )
+                }
+
+                // Marker dots on each captured corner.
+                projected.forEach { p ->
+                    drawCircle(color = Color.Yellow, radius = 6.dp.toPx(), center = p)
+                    drawCircle(
+                        color = Color.White,
+                        radius = 6.dp.toPx(),
+                        center = p,
+                        style = Stroke(width = 1.5.dp.toPx())
+                    )
+                }
             }
         }
 
@@ -471,9 +512,9 @@ fun TableScanScreen(
                         val placed = cornerTaps.size
                         Text(
                             text = when {
-                                placed == 0 -> "Tap the four corner pockets"
-                                placed < 4 -> "Tap the next corner pocket ($placed of 4)"
-                                else -> "Drag a corner to refine, then confirm"
+                                placed == 0 -> "Aim the crosshair at a corner pocket and tap Capture"
+                                placed < 4 -> "Aim at the next corner pocket and tap Capture ($placed of 4)"
+                                else -> "All four corners marked — tap the check to confirm"
                             },
                             color = Color.White,
                             style = MaterialTheme.typography.bodyLarge,
@@ -502,6 +543,9 @@ fun TableScanScreen(
                             TextButton(onClick = { viewModel.clearCornerTaps() }) {
                                 Text("Reset", color = Color.White)
                             }
+
+                            // Capture shutter — marks the pocket under the crosshair.
+                            val captureEnabled = placed < 4
                             Box(modifier = Modifier.size(80.dp).padding(4.dp)) {
                                 Canvas(modifier = Modifier.fillMaxSize()) {
                                     drawCircle(color = Color.White.copy(alpha = 0.2f), style = Stroke(width = 4.dp.toPx()))
@@ -514,9 +558,31 @@ fun TableScanScreen(
                                 Box(
                                     modifier = Modifier
                                         .align(Alignment.Center).size(64.dp).clip(CircleShape)
-                                        .background(if (placed == 4) Color.White else Color.LightGray.copy(alpha = 0.5f))
+                                        .background(if (captureEnabled) Color.White else Color.LightGray.copy(alpha = 0.5f))
                                         .border(4.dp, Color.LightGray, CircleShape)
-                                        .clickable(enabled = placed == 4) {
+                                        .clickable(enabled = captureEnabled) {
+                                            val haptic = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                                                HapticFeedbackConstants.CONFIRM
+                                            } else {
+                                                HapticFeedbackConstants.LONG_PRESS
+                                            }
+                                            view.performHapticFeedback(haptic)
+                                            isCapturingCorner = true
+                                            cornerCaptureCount++
+                                            viewModel.captureCornerAtCrosshair()
+                                        }
+                                )
+                            }
+
+                            // Confirm — commits the polygon once all four corners are placed.
+                            val confirmEnabled = placed == 4
+                            Box(modifier = Modifier.size(64.dp).padding(4.dp)) {
+                                Box(
+                                    modifier = Modifier
+                                        .align(Alignment.Center).size(56.dp).clip(CircleShape)
+                                        .background(if (confirmEnabled) Color.Green else Color.DarkGray.copy(alpha = 0.5f))
+                                        .border(2.dp, Color.White, CircleShape)
+                                        .clickable(enabled = confirmEnabled) {
                                             val haptic = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                                                 HapticFeedbackConstants.CONFIRM
                                             } else {
@@ -525,7 +591,14 @@ fun TableScanScreen(
                                             view.performHapticFeedback(haptic)
                                             viewModel.completeCornerScan()
                                         }
-                                )
+                                ) {
+                                    Text(
+                                        text = "✓",
+                                        color = Color.White,
+                                        style = MaterialTheme.typography.titleLarge,
+                                        modifier = Modifier.align(Alignment.Center)
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanViewModel.kt
@@ -90,9 +90,16 @@ class TableScanViewModel @Inject constructor(
     val capturedFeltHsv: StateFlow<FloatArray?> = _capturedFeltHsv.asStateFlow()
 
     /**
-     * Corner-quad scan: up to 4 screen-space tap positions for the four corner pockets.
-     * Order in the list maps to TL, TR, BR, BL once committed. While the user is tapping,
-     * positions are appended in tap order; on commit they are reordered by screen geometry.
+     * Corner-quad scan: up to 4 *logical-space* points for the four corner pockets.
+     *
+     * Each point is captured by aiming the centre crosshair at a corner pocket and
+     * tapping Capture, exactly like felt-colour capture. At capture time the screen
+     * centre is projected to logical space via the current inverse pitch matrix, so
+     * the points stay anchored to the table plane as the device tilts. The UI projects
+     * them back to screen space (via the live pitch matrix) to draw the polygon.
+     *
+     * Order in the list is capture order; on commit they are reordered by geometry
+     * into TL, TR, BR, BL.
      */
     private val _cornerTaps = MutableStateFlow<List<PointF>>(emptyList())
     val cornerTaps: StateFlow<List<PointF>> = _cornerTaps.asStateFlow()
@@ -505,18 +512,21 @@ class TableScanViewModel @Inject constructor(
         }
     }
 
-    fun onCornerTap(screenPoint: PointF) {
+    /**
+     * Capture the corner pocket currently under the centre crosshair.
+     *
+     * Mirrors felt-colour capture: the user aims the centre of the screen at a corner
+     * pocket and taps. The screen centre is projected to logical space (anchored to the
+     * table plane) and appended to the running list. A maximum of four corners are kept.
+     */
+    fun captureCornerAtCrosshair() {
         if (_scanStep.value != ScanStep.CORNER_QUAD) return
-        val current = _cornerTaps.value
-        if (current.size >= 4) return
-        _cornerTaps.value = current + screenPoint
-    }
-
-    fun onCornerDrag(index: Int, screenPoint: PointF) {
-        if (_scanStep.value != ScanStep.CORNER_QUAD) return
-        val current = _cornerTaps.value
-        if (index !in current.indices) return
-        _cornerTaps.value = current.toMutableList().also { it[index] = screenPoint }
+        val inverse = inversePitchMatrix ?: return
+        if (_cornerTaps.value.size >= 4) return
+        if (viewWidth <= 0 || viewHeight <= 0) return
+        val screenCenter = PointF(viewWidth / 2f, viewHeight / 2f)
+        val logicalPt = Perspective.screenToLogical(screenCenter, inverse)
+        _cornerTaps.value = _cornerTaps.value + logicalPt
     }
 
     fun clearCornerTaps() {
@@ -524,8 +534,10 @@ class TableScanViewModel @Inject constructor(
     }
 
     /**
-     * Sorts four screen-space corner taps into TL/TR/BR/BL order based on their
-     * geometric position relative to the centroid.
+     * Sorts four logical-space corner points into TL/TR/BR/BL order based on their
+     * geometric position relative to the centroid. Logical space shares the screen's
+     * y-convention (smaller y = top / far rail), matching Table.kt where the top
+     * pockets sit at -halfH, so a top/bottom split by centroid is correct.
      */
     private fun sortCornersClockwise(corners: List<PointF>): List<PointF> {
         if (corners.size != 4) return corners
@@ -537,21 +549,23 @@ class TableScanViewModel @Inject constructor(
     }
 
     /**
-     * Commit the four corner taps. Maps each screen point to logical space,
-     * derives the two side pockets from the long-side midpoints, fits a homography,
-     * and completes the scan.
+     * Commit the four captured corner pockets. The taps are already logical-space
+     * points (captured under the crosshair). This derives the two side pockets from
+     * the long-side midpoints, fits a homography, and completes the scan.
+     *
+     * Unlike the old flow this does not depend on a live inverse matrix at commit
+     * time, so the confirm button works regardless of the current device pose.
      */
     fun completeCornerScan() {
-        val inverse = inversePitchMatrix ?: return
         val taps = _cornerTaps.value
         if (taps.size != 4) return
 
         viewModelScope.launch {
             val sorted = sortCornersClockwise(taps)
-            val tl = Perspective.screenToLogical(sorted[0], inverse)
-            val tr = Perspective.screenToLogical(sorted[1], inverse)
-            val br = Perspective.screenToLogical(sorted[2], inverse)
-            val bl = Perspective.screenToLogical(sorted[3], inverse)
+            val tl = sorted[0]
+            val tr = sorted[1]
+            val br = sorted[2]
+            val bl = sorted[3]
 
             // SL/SR are the two side pockets, which sit at the midpoints of the
             // long rails. The left long rail runs TL→BL, so SL is the midpoint of


### PR DESCRIPTION
## What & why

In expert mode the corner-pocket marking step used a tap-and-drag four-circles interaction, and the "finish" button did nothing. Tapping **glasses** also appeared to do nothing. This reworks both.

### Pocket marking → crosshair capture (like felt colour capture)
- The user aims the **centre crosshair** at each corner pocket and taps **Capture**. The screen centre is projected to logical space at capture time and anchored to the table plane (same projection the per-pocket wizard uses).
- Captured corners are re-projected through the **live pitch matrix** every frame and joined with polygon edges. A rubber-band line trails from the **last marked pocket to the crosshair**, so the user visibly *draws* the table polygon.
- A separate **Confirm (✓)** button commits the four corners once all are placed; **Reset** clears them.
- Still captures the 4 corner pockets and derives the 2 side pockets from the rail midpoints (unchanged geometry), per the chosen design.

### Why "finish did nothing"
The old `completeCornerScan()` bailed out at `inversePitchMatrix ?: return` and converted screen taps at commit time. The new flow captures logical points up front and the commit path no longer needs a live inverse matrix, so Confirm always works once four corners are placed.

### Glasses feedback
`MetaWearableBackground` previously rendered nothing when there was no video frame, so the toggle looked dead. Added a `MetaConnectionStatus` flow (`CONNECTING / STREAMING / NO_DEVICE / ERROR`) plus a `lastError` detail to `MetaWearableRepository`, and the background now shows a status message (e.g. "Connecting to glasses…", "No Meta glasses found…"). The toggle wiring itself was already correct (`SetCameraMode(META_GLASSES)` → `startStreaming()`); this makes failures visible and adds diagnostics.

## Files
- `tablescan/TableScanViewModel.kt` — `captureCornerAtCrosshair()`, logical-space corners, matrix-independent `completeCornerScan()`.
- `tablescan/TableScanScreen.kt` — corner crosshair reticle, projected polygon + trailing line, Capture/Confirm/Reset controls.
- `data/MetaWearableRepository.kt` — connection status + last-error flows.
- `ui/composables/MetaWearableBackground.kt` — status overlay.

## Testing
- Not compiled in CI here: the project pins a JetBrains-vendor JDK 21 toolchain that requires network provisioning, which is blocked in this environment. Verified by review.
- **Glasses**: needs a hardware check on paired Meta glasses to confirm the stream starts and the status overlay reflects each state.
- **Pocket capture**: please sanity-check that tilting/aiming between captures yields distinct, well-anchored corners and that the derived table geometry is correct.

https://claude.ai/code/session_01NyT38M2Ko7h5BKkdD6YdaZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyT38M2Ko7h5BKkdD6YdaZ)_

## Summary by Sourcery

Switch expert-mode corner pocket detection to a crosshair-based capture flow and surface Meta glasses connection status in the background view.

New Features:
- Allow capturing corner pockets by aiming a central crosshair and tapping a Capture control, with a separate Confirm action once all four corners are marked.
- Display Meta glasses connection and error status messages when no video frame is available, instead of leaving the background blank.

Bug Fixes:
- Ensure the corner scan Confirm action no longer fails silently when the inverse pitch matrix is unavailable at commit time.

Enhancements:
- Anchor captured corner pockets in logical table space and reproject them via the live pitch matrix so the table polygon stays aligned as the device moves.
- Render a dynamic polygon overlay with trailing rubber-band line and updated guidance copy during corner capture to better visualize the table outline.
- Expose a coarse Meta glasses connection state and last-error message from the repository for use in the UI.