### PR TITLE
Pin Bouncy Castle 1.84 via explicit constraints for Dependabot

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -306,6 +306,21 @@ android {
 
 
 dependencies {
+    // Bouncy Castle is pulled in transitively. The resolutionStrategy below
+    // (configurations.all) force-upgrades it at resolution time, but Dependabot
+    // parses build files statically and does not evaluate that dynamic override,
+    // so it keeps flagging the vulnerable transitive versions (CVE-2026-5598 and
+    // the older bcpkix/LDAP-injection advisories). These explicit constraints
+    // pin the patched 1.84 in a form static analysis recognizes, so the alerts
+    // resolve. Keep the version in sync with libs.versions.bouncycastle.
+    constraints {
+        val bcVersion = libs.versions.bouncycastle.get()
+        implementation("org.bouncycastle:bcprov-jdk18on:$bcVersion")
+        implementation("org.bouncycastle:bcpkix-jdk18on:$bcVersion")
+        implementation("org.bouncycastle:bcutil-jdk18on:$bcVersion")
+        implementation("org.bouncycastle:bctls-jdk18on:$bcVersion")
+    }
+
     implementation(libs.androidx.datastore.preferences)
 
     // Play Billing — only included in the play flavor APK.


### PR DESCRIPTION
The resolutionStrategy already force-upgrades org.bouncycastle to 1.84, but Dependabot evaluates build files statically and ignores that dynamic override, so it keeps flagging the vulnerable transitive versions (CVE-2026-5598 covert timing channel, plus the older bcpkix broken-algorithm and bcprov LDAP-injection advisories). Add explicit dependency constraints on the BC modules so the patched 1.84 pin is visible to static analysis and the alerts resolve. Version stays sourced from libs.versions.bouncycastle.

https://claude.ai/code/session_01NyT38M2Ko7h5BKkdD6YdaZ

## Summary by Sourcery

Build:
- Add explicit Gradle dependency constraints for Bouncy Castle modules using the shared bouncycastle version catalog entry to surface the 1.84 pin to static analysis tools.