### PR TITLE
Table-height fixes: AR slider mapping + non-AR roll-leak

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/data/ArTableSession.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/data/ArTableSession.kt
@@ -63,6 +63,11 @@ class ArTableSession @Inject constructor(
     // Ideal logical corner positions (TL, TR, BR, BL), set when a scan begins.
     @Volatile private var idealCorners: List<Pt> = emptyList()
 
+    // Height of the table plane above the captured anchors, in metres, driven by the tableZOffset
+    // slider. Lets the user nudge the virtual table up off the floor-plane hit-test to sit on the
+    // rail (the hit-test lands on the floor under the pocket, ~rail-height below the real pocket).
+    @Volatile private var tableHeightMeters: Float = 0f
+
     private val _capturedCount = MutableStateFlow(0)
     /** Number of corner anchors captured so far (0..4). Observed by the scan UI. */
     val capturedCount: StateFlow<Int> = _capturedCount.asStateFlow()
@@ -109,6 +114,11 @@ class ArTableSession @Inject constructor(
     /** Sets the ideal logical corner layout (TL, TR, BR, BL) for the table being scanned. */
     fun setIdealCorners(corners: List<Pt>) {
         idealCorners = corners
+    }
+
+    /** Sets the table-plane lift above the captured anchors (tableZOffset slider, in metres). */
+    fun setTableHeightMeters(meters: Float) {
+        tableHeightMeters = meters
     }
 
     /** Queues a corner capture; the next GL frame performs the hit-test at screen centre. */
@@ -219,7 +229,7 @@ class ArTableSession @Inject constructor(
         if (ordered.any { it.trackingState != TrackingState.TRACKING }) return null
         val cornersWorld = ordered.map { anchorWorld(it) ?: return null }
         val h = TableFrameHomography.computeLogicalToScreen(
-            view, proj, cornersWorld, idealCorners, vpW, vpH
+            view, proj, cornersWorld, idealCorners, vpW, vpH, heightMeters = tableHeightMeters
         ) ?: return null
         return Matrix().apply { setValues(h) }
     }

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
@@ -524,6 +524,10 @@ class MainViewModel @Inject constructor(
         _uiState.value = derivedState
         visionAnalyzer.updateUiState(derivedState)
         arFrameProcessor.updateUiState(derivedState)
+        // tableZOffset is in logical units; convert to metres for the AR plane lift.
+        arTableSession.setTableHeightMeters(
+            derivedState.tableZOffset / com.hereliesaz.cuedetat.domain.TableFrameHomography.LOGICAL_UNITS_PER_METER
+        )
 
         // Persist tutorial-seen flags the moment they flip. They live in
         // dedicated DataStore keys (not STATE_JSON) so they're not subject to

--- a/app/src/main/java/com/hereliesaz/cuedetat/view/model/Perspective.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/view/model/Perspective.kt
@@ -123,19 +123,27 @@ object Perspective {
             // We clamp the final value to -90..90 just to be safe from invalid inputs.
             camera.rotateX(visualPitch.coerceIn(-90f, 90f))
 
+            // Apply the height lift HERE — in the pitch-tilted frame but BEFORE the roll rotation.
+            // Previously the lift was applied after rotateZ(roll), so any device roll rotated the
+            // vertical lift sideways and the table height leaked onto the X axis instead of rising
+            // straight out of the table plane. Applying it before the roll keeps height aligned with
+            // the table's own "up" regardless of how the phone is rolled. (At lift == 0 this is a
+            // no-op, so the flat/no-height case renders identically to before.)
+            camera.translate(0f, lift, 0f)
+
             // Apply gentle roll — 30% of physical roll for subtle tilt without disorientation.
             val visualRoll = currentOrientation.roll * 0.3f
             camera.rotateZ(visualRoll)
-        }
 
-        // Translate the camera in 3D space.
-        // 1. x=0f: No horizontal shift.
-        // 2. y=lift: Apply the "lift" argument. Positive values move the object down (or camera up),
-        //    simulating height (used for rail tops).
-        // 3. z=-32f: Move the camera back along the Z-axis.
-        //    The value -32f is a "magic number" standard in Android's Camera class that roughly approximates
-        //    a standard viewing distance. Without this, the perspective distortion would be too extreme or inverted.
-        camera.translate(0f, lift, -32f)
+            // Move the camera back along the Z-axis. The value -32f is a "magic number" standard in
+            // Android's Camera class that roughly approximates a standard viewing distance. Without
+            // this, the perspective distortion would be too extreme or inverted.
+            camera.translate(0f, 0f, -32f)
+        } else {
+            // No perspective tilt: keep the original single translate (lift + viewing distance).
+            // Height is not visually meaningful in the flat/top-down view, so this is unchanged.
+            camera.translate(0f, lift, -32f)
+        }
 
         // Compute the matrix for the current Camera state and store it in our `matrix` object.
         camera.getMatrix(matrix)


### PR DESCRIPTION
Two deferred follow-ups from #226.

## 1. AR table-height slider → metres (`tableZOffset`)

In AR the table-height slider did nothing — the homography was computed with height 0. This converts
`tableZOffset` (logical units) to metres and lifts the table plane along the **ARCore plane normal**,
so height is applied in world space with the projection (the right place). Besides honouring the
slider, this lets the user nudge the table up off the floor-plane hit-test to sit on the rail — the
hit-test lands on the floor *under* the pocket, ~rail-height below the real pocket, which was the
top risk called out in #226.

- `ArTableSession`: new `tableHeightMeters` + `setTableHeightMeters`, passed to
  `computeLogicalToScreen(heightMeters = …)`.
- `MainViewModel`: feeds `tableZOffset / LOGICAL_UNITS_PER_METER` to the session on each state update.

## 2. Non-AR height leaking onto the X axis under device roll

This is my read of the reported bug ("height affects the X axis, not Z, because it's not factored in
with the rotations"). In `Perspective.createPerspectiveMatrix` the lift was applied as
`camera.translate(0, lift, -32)` **after** `rotateZ(roll)`, so any device roll rotated the vertical
lift sideways and the table/rail height drifted onto X instead of rising straight out of the table
plane. The fix applies the lift in the pitch-tilted frame **before** the roll, with the viewing
pull-back kept last.

**Safety:** at `lift == 0` this is an identity translate between the same two rotations, so the
flat/no-height path renders **identically**. Only the genuine-height case (rails, non-zero
`tableZOffset`) changes — which is exactly the buggy case.

## ⚠️ Needs on-device verification (CI can't validate rendering)

Neither change can be validated by CI (it only compiles) — both affect visual geometry. Please check
on a device:

- **AR:** the height slider now raises/lowers the virtual table; nudge it up so the table sits on the
  rail rather than sinking into the floor.
- **Non-AR:** roll the phone side-to-side with rails visible (or a non-zero height) — rail height
  should stay vertical relative to the table instead of skewing sideways. Confirm the flat/top-down
  and zero-height views look unchanged.

**One open question on #2:** if the height you saw skewing was tied to the **table-rotation slider
(`worldRotationDegrees`)** rather than phone *roll*, that's a different, larger fix — `worldRotation`
lives in a separate 2D matrix stage and would need to be folded into the 3D camera transform. Tell me
which and I'll adjust.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3Qyxf8XkGdE33pzgs4fC4)_