### PR TITLE
Non-AR height slider: slide the table vertically on screen, not into it

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/domain/UpdateStateUseCase.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/domain/UpdateStateUseCase.kt
@@ -37,6 +37,10 @@ class UpdateStateUseCase @Inject constructor(
     private val distanceReferenceConstant = 1200f
     private val lineExtensionFactor = 5000f
 
+    // Screen fraction the table-height slider moves per tableZOffset unit. tableZOffset is ±50, so
+    // ±50 * 0.008 = ±0.4 -> the table slides up to ~40% of the screen height each way. Tunable.
+    private val HEIGHT_SCREEN_FACTOR = 0.008f
+
     // Assumed camera height above the table surface when no ARCore anchor is available.
     // Derived from: user eye height ≈ 4.5 ft above floor, pool table ≈ 3 ft above floor → 1.5 ft ≈ 0.45 m.
     private val assumedHeightAboveTableM = 0.45f
@@ -178,7 +182,10 @@ class UpdateStateUseCase @Inject constructor(
         val perspectiveMatrix = Perspective.createPerspectiveMatrix(
             currentOrientation = orientationForPerspective,
             camera = camera,
-            lift = stateWithCoercedPan.tableZOffset,
+            // tableZOffset no longer feeds the 3D camera lift (that just pushed the table into the
+            // screen). The height slider is applied as a screen-space vertical translate in
+            // createFullMatrix instead; only the genuine rail lift stays a 3D effect.
+            lift = 0f,
             applyPitch = isPitchApplied
         )
 
@@ -195,7 +202,8 @@ class UpdateStateUseCase @Inject constructor(
         val railPerspectiveMatrix = Perspective.createPerspectiveMatrix(
             currentOrientation = orientationForPerspective,
             camera = camera,
-            lift = railLiftAmount + stateWithCoercedPan.tableZOffset,
+            // Rails keep their genuine 3D lift; tableZOffset is handled in screen space (below).
+            lift = railLiftAmount,
             applyPitch = isPitchApplied
         )
         val finalRailPitchMatrix =
@@ -510,6 +518,15 @@ class UpdateStateUseCase @Inject constructor(
         finalMatrix.set(worldMatrix)
         finalMatrix.postConcat(perspectiveMatrix)
         finalMatrix.postTranslate(centerX, centerY)
+
+        // Table-height slider: slide the WHOLE projected table straight up/down the screen, through
+        // its centre, keeping its perspective shape (the user wants it to translate along a vertical
+        // line, not get pushed into the distance). A uniform screen-space translate on every matrix
+        // built here keeps the table rigid and keeps the derived inverse consistent for hit-testing.
+        // Positive tableZOffset raises the table on screen (negative Y); flip the sign here if the
+        // slider direction feels inverted. Computed from viewHeight (not zoom) so all matrices agree.
+        val heightOffsetY = -state.tableZOffset * state.viewHeight * HEIGHT_SCREEN_FACTOR
+        finalMatrix.postTranslate(0f, heightOffsetY)
         return finalMatrix
     }
 


### PR DESCRIPTION
## Problem

The non-AR table-height slider didn't move the table the way it should. It fed `tableZOffset` into
the 3D **camera lift** (`camera.translate(0, lift, -32)`), so with the table tilted in perspective
the "height" mostly became a **depth** nudge — the table barely shifted, just scaled slightly and
changed the **Distance** readout (the user's comparison shots showed Distance going 14′5″→16′2″ with
almost no visible movement).

The user wants the height slider to slide the **whole table rigidly straight up/down the screen,
through its centre, keeping its perspective shape** — drawn as the table copied above and below
itself along a vertical line.

## Fix

Separate the two meanings that were conflated in the `lift` argument (all in `UpdateStateUseCase.kt`):

- **Rails** keep their genuine 3D lift (`railLiftAmount`) — rails still stick up in perspective.
- **`tableZOffset`** is removed from the camera lift and instead applied as a uniform **screen-space
  vertical translate** at the end of `createFullMatrix`:
  `postTranslate(0, -tableZOffset * viewHeight * HEIGHT_SCREEN_FACTOR)`.

Because every matrix built in `createFullMatrix` (pitch, rail, flat, logical, size) gets the same
offset, the table moves rigidly and the inverse stays consistent for hit-testing. The offset is
computed from `viewHeight` (not `zoom`) so all matrices agree.

Side effect (correct): height no longer changes depth, so the **Distance** readout stops drifting
when you adjust height.

AR is unaffected — the AR path returns early in `updateMatricesAndTransforms` and handles height via
the plane-normal lift from #227.

## Notes / tuning

- Sign: positive `tableZOffset` raises the table (negative screen-Y). One-line flip if the slider
  feels inverted.
- Magnitude: `HEIGHT_SCREEN_FACTOR = 0.008` → ±50 moves ~±40% of screen height. Easily tunable.

## Verification

CI compiles only (sandbox can't build — placeholder AGP `9.2.1`). On device, non-AR expert mode:
drag the height slider — the whole table should slide straight up/down through its centre with its
shape unchanged, no Distance drift, no depth shrink. Check at a couple of Table Rotation values
(e.g. 2°, 51°) that the motion stays vertical, that rails still render raised, and that
`tableZOffset = 0` looks identical to before.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3Qyxf8XkGdE33pzgs4fC4)_