### PR TITLE
Expert AR table-scan as an on-demand dynamic feature module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -207,7 +207,7 @@ android {
     // via Play Feature Delivery; the `foss` flavor pulls the same asset directly
     // (see the sourceSets block below) because standalone FOSS APKs cannot use
     // split installs.
-    dynamicFeatures += setOf(":feature_mlmodel")
+    dynamicFeatures += setOf(":feature_mlmodel", ":feature_expert_ar")
 
     defaultConfig {
         applicationId = "com.hereliesaz.cuedetat"
@@ -262,6 +262,11 @@ android {
     sourceSets {
         getByName("foss") {
             assets.srcDir(rootProject.file("feature_mlmodel/src/main/assets"))
+            // FOSS APKs have no Play split channel, so the Expert-AR module's
+            // sources are compiled directly into the foss APK (ARCore is added as
+            // a fossImplementation dependency below). The play flavor omits this
+            // and fetches the :feature_expert_ar split on demand instead.
+            java.srcDir(rootProject.file("feature_expert_ar/src/main/java"))
         }
     }
 
@@ -420,8 +425,11 @@ dependencies {
     implementation(libs.mlkit)
     implementation(libs.opencv)
 
-    // ARCore — Depth API (optional; app degrades gracefully on unsupported devices)
-    implementation(libs.core)
+    // ARCore now lives in the on-demand :feature_expert_ar dynamic feature, so
+    // the play base AAB ships without it. The foss flavor compiles that module's
+    // sources directly into the APK (see the foss sourceSet above), so it needs
+    // ARCore on its own classpath.
+    "fossImplementation"(libs.core)
 
     // TFLite — pocket detection model
     implementation(libs.tensorflow.lite)

--- a/app/src/foss/java/com/hereliesaz/cuedetat/delivery/FossArFeatureDelivery.kt
+++ b/app/src/foss/java/com/hereliesaz/cuedetat/delivery/FossArFeatureDelivery.kt
@@ -1,0 +1,15 @@
+// FILE: app/src/foss/java/com/hereliesaz/cuedetat/delivery/FossArFeatureDelivery.kt
+
+package com.hereliesaz.cuedetat.delivery
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * FOSS-flavor [ArFeatureDelivery]: a no-op. The foss APK compiles the
+ * `:feature_expert_ar` sources directly in (its source set includes the module's
+ * java srcDir and ARCore), so `ArControllerImpl` is always loadable and every
+ * default in [ArFeatureDelivery] applies.
+ */
+@Singleton
+class FossArFeatureDelivery @Inject constructor() : ArFeatureDelivery

--- a/app/src/foss/java/com/hereliesaz/cuedetat/di/FossDeliveryModule.kt
+++ b/app/src/foss/java/com/hereliesaz/cuedetat/di/FossDeliveryModule.kt
@@ -2,6 +2,8 @@
 
 package com.hereliesaz.cuedetat.di
 
+import com.hereliesaz.cuedetat.delivery.ArFeatureDelivery
+import com.hereliesaz.cuedetat.delivery.FossArFeatureDelivery
 import com.hereliesaz.cuedetat.delivery.FossModelDelivery
 import com.hereliesaz.cuedetat.delivery.ModelDelivery
 import dagger.Binds
@@ -10,7 +12,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
-/** Binds the no-op model delivery for FOSS builds (model bundled in the APK). */
+/** Binds the no-op deliveries for FOSS builds (model + AR code bundled in the APK). */
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class FossDeliveryModule {
@@ -18,4 +20,8 @@ abstract class FossDeliveryModule {
     @Binds
     @Singleton
     abstract fun bindModelDelivery(impl: FossModelDelivery): ModelDelivery
+
+    @Binds
+    @Singleton
+    abstract fun bindArFeatureDelivery(impl: FossArFeatureDelivery): ArFeatureDelivery
 }

--- a/app/src/main/java/com/hereliesaz/cuedetat/arfeature/ArController.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/arfeature/ArController.kt
@@ -25,6 +25,14 @@ import com.hereliesaz.cuedetat.domain.MainScreenEvent
  */
 interface ArController {
 
+    /**
+     * Ensure the Expert-AR implementation is available, requesting the on-demand
+     * `:feature_expert_ar` split if necessary. Entitlement-gated: returns false
+     * (and stays a no-op) for users who are not entitled. Implemented by the
+     * facade; the loaded implementation and the no-op both use the default.
+     */
+    suspend fun ensureLoaded(): Boolean = true
+
     /** Detect ARCore world-tracking capability (creates and closes a probe session). */
     fun probeCapability(): DepthCapability
 

--- a/app/src/main/java/com/hereliesaz/cuedetat/arfeature/ArControllerFacade.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/arfeature/ArControllerFacade.kt
@@ -12,8 +12,10 @@ import com.hereliesaz.cuedetat.delivery.ArFeatureDelivery
 import com.hereliesaz.cuedetat.domain.CueDetatState
 import com.hereliesaz.cuedetat.domain.MainScreenEvent
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -48,13 +50,17 @@ class ArControllerFacade @Inject constructor(
         if (!delivery.ensureInstalled()) return false
         return loadMutex.withLock {
             if (loaded) return@withLock true
-            val impl = runCatching {
-                Class.forName(
-                    "com.hereliesaz.cuedetat.feature.expert.ar.ArControllerImpl",
-                    true,
-                    context.classLoader,
-                ).getConstructor(Context::class.java).newInstance(context) as ArController
-            }.getOrNull() ?: return@withLock false
+            // Reflective class loading + instantiation can touch disk (loading a
+            // freshly installed split's dex), so keep it off the main thread.
+            val impl = withContext(Dispatchers.IO) {
+                runCatching {
+                    Class.forName(
+                        "com.hereliesaz.cuedetat.feature.expert.ar.ArControllerImpl",
+                        true,
+                        context.classLoader,
+                    ).getConstructor(Context::class.java).newInstance(context) as ArController
+                }.getOrNull()
+            } ?: return@withLock false
             delegate = impl
             loaded = true
             true

--- a/app/src/main/java/com/hereliesaz/cuedetat/arfeature/ArControllerFacade.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/arfeature/ArControllerFacade.kt
@@ -1,0 +1,88 @@
+package com.hereliesaz.cuedetat.arfeature
+
+import android.content.Context
+import androidx.camera.core.ImageAnalysis
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.hereliesaz.cuedetat.billing.EntitlementRepository
+import com.hereliesaz.cuedetat.delivery.ArFeatureDelivery
+import com.hereliesaz.cuedetat.domain.CueDetatState
+import com.hereliesaz.cuedetat.domain.MainScreenEvent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The base-bound [ArController]. Stays stable for the app's lifetime while
+ * swapping its [delegate] from [NoOpArController] to the real implementation once
+ * the on-demand `:feature_expert_ar` split is available.
+ *
+ * Loading is entitlement-gated: [ensureLoaded] is a no-op (returns false) until
+ * the user is entitled, so un-entitled users never download or run the AR code.
+ * The implementation class lives in the dynamic feature module and is resolved
+ * reflectively — the base has no compile-time dependency on it or on ARCore.
+ *
+ * [delegate] is a Compose [mutableStateOf] so the @Composable surfaces recompose
+ * onto the real implementation the moment it loads.
+ */
+@Singleton
+class ArControllerFacade @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val entitlementRepository: EntitlementRepository,
+    private val delivery: ArFeatureDelivery,
+) : ArController {
+
+    private var delegate by mutableStateOf<ArController>(NoOpArController)
+    private val loadMutex = Mutex()
+    @Volatile private var loaded = false
+
+    override suspend fun ensureLoaded(): Boolean {
+        if (loaded) return true
+        // Entitlement gate: never fetch or run the Expert-AR code for free users.
+        if (!entitlementRepository.entitlement.value.active) return false
+        if (!delivery.ensureInstalled()) return false
+        return loadMutex.withLock {
+            if (loaded) return@withLock true
+            val impl = runCatching {
+                Class.forName(
+                    "com.hereliesaz.cuedetat.feature.expert.ar.ArControllerImpl",
+                    true,
+                    context.classLoader,
+                ).getConstructor(Context::class.java).newInstance(context) as ArController
+            }.getOrNull() ?: return@withLock false
+            delegate = impl
+            loaded = true
+            true
+        }
+    }
+
+    override fun probeCapability() = delegate.probeCapability()
+
+    override fun updateUiState(state: CueDetatState) = delegate.updateUiState(state)
+
+    override fun setTableZOffsetLogical(tableZOffsetLogical: Float) =
+        delegate.setTableZOffsetLogical(tableZOffsetLogical)
+
+    @Composable
+    override fun ArBackground(modifier: Modifier, onEvent: (MainScreenEvent) -> Unit) =
+        delegate.ArBackground(modifier, onEvent)
+
+    // Stable analyzer that forwards each frame to the current delegate, so the
+    // value remembered by ProtractorScreen keeps working across a delegate swap.
+    private val analyzerForwarder = ImageAnalysis.Analyzer { proxy ->
+        delegate.scanAnalyzer().analyze(proxy)
+    }
+
+    override fun scanAnalyzer(): ImageAnalysis.Analyzer = analyzerForwarder
+
+    @Composable
+    override fun ScanOverlay(uiState: CueDetatState, onEvent: (MainScreenEvent) -> Unit) =
+        delegate.ScanOverlay(uiState, onEvent)
+
+    override fun startManualHoleCapture() = delegate.startManualHoleCapture()
+}

--- a/app/src/main/java/com/hereliesaz/cuedetat/arfeature/ArFeatureEntryPoint.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/arfeature/ArFeatureEntryPoint.kt
@@ -1,0 +1,23 @@
+package com.hereliesaz.cuedetat.arfeature
+
+import com.hereliesaz.cuedetat.data.TableScanRepository
+import com.hereliesaz.cuedetat.data.VisionRepository
+import com.hereliesaz.cuedetat.ui.composables.tablescan.PocketDetector
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+/**
+ * Hilt entry point exposing the base singletons that the on-demand
+ * `:feature_expert_ar` module needs. Hilt does not extend into dynamic feature
+ * modules, so `ArControllerImpl` (in the module) pulls these via
+ * `EntryPointAccessors.fromApplication(context, ArFeatureEntryPoint::class.java)`
+ * instead of constructor injection.
+ */
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface ArFeatureEntryPoint {
+    fun visionRepository(): VisionRepository
+    fun tableScanRepository(): TableScanRepository
+    fun pocketDetector(): PocketDetector
+}

--- a/app/src/main/java/com/hereliesaz/cuedetat/arfeature/NoOpArController.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/arfeature/NoOpArController.kt
@@ -1,0 +1,33 @@
+package com.hereliesaz.cuedetat.arfeature
+
+import androidx.camera.core.ImageAnalysis
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.hereliesaz.cuedetat.domain.CueDetatState
+import com.hereliesaz.cuedetat.domain.DepthCapability
+import com.hereliesaz.cuedetat.domain.MainScreenEvent
+
+/**
+ * Inert [ArController] used by [ArControllerFacade] before the Expert-AR module
+ * is loaded (and permanently for un-entitled users). Reports no AR capability,
+ * so the AR/scan UI in the base never composes and the per-frame hooks are
+ * harmless no-ops.
+ */
+object NoOpArController : ArController {
+
+    override fun probeCapability(): DepthCapability = DepthCapability.NONE
+
+    override fun updateUiState(state: CueDetatState) {}
+
+    override fun setTableZOffsetLogical(tableZOffsetLogical: Float) {}
+
+    @Composable
+    override fun ArBackground(modifier: Modifier, onEvent: (MainScreenEvent) -> Unit) {}
+
+    override fun scanAnalyzer(): ImageAnalysis.Analyzer = ImageAnalysis.Analyzer { it.close() }
+
+    @Composable
+    override fun ScanOverlay(uiState: CueDetatState, onEvent: (MainScreenEvent) -> Unit) {}
+
+    override fun startManualHoleCapture() {}
+}

--- a/app/src/main/java/com/hereliesaz/cuedetat/delivery/ArFeatureDelivery.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/delivery/ArFeatureDelivery.kt
@@ -1,0 +1,31 @@
+// FILE: app/src/main/java/com/hereliesaz/cuedetat/delivery/ArFeatureDelivery.kt
+
+package com.hereliesaz.cuedetat.delivery
+
+/**
+ * Flavor-specific delivery of the `:feature_expert_ar` dynamic feature module
+ * (the Expert-only ARCore table-scan flow + ARCore itself).
+ *
+ *  - **foss**: the module's sources are compiled directly into the APK (the foss
+ *    flavor adds the module's java srcDir and ARCore), so the code is always
+ *    present and there is nothing to install.
+ *  - **play**: the base AAB ships *without* the AR code or ARCore. The split is
+ *    delivered on demand via Play Feature Delivery the first time an entitled
+ *    user enters Expert AR.
+ *
+ * Only the install concern lives here; the base resolves the implementation
+ * class reflectively (see ArControllerFacade) so the Play-only SplitInstall APIs
+ * never leak into the foss build.
+ */
+interface ArFeatureDelivery {
+
+    /** True when the AR code is already loadable in this process. Always true for foss. */
+    val isInstalled: Boolean get() = true
+
+    /**
+     * Ensures the AR split is installed (and its classes loadable), requesting it
+     * on demand if necessary. Suspends until install completes (play) or returns
+     * immediately (foss). Returns true when the code is available afterwards.
+     */
+    suspend fun ensureInstalled(): Boolean = true
+}

--- a/app/src/main/java/com/hereliesaz/cuedetat/di/ArFeatureModule.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/di/ArFeatureModule.kt
@@ -3,7 +3,7 @@
 package com.hereliesaz.cuedetat.di
 
 import com.hereliesaz.cuedetat.arfeature.ArController
-import com.hereliesaz.cuedetat.arfeature.BaseArController
+import com.hereliesaz.cuedetat.arfeature.ArControllerFacade
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -11,9 +11,9 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 /**
- * Binds the in-base [ArController]. Step 2 of the Expert-AR extraction swaps this
- * for a provider that resolves the implementation from the on-demand
- * `:feature_expert_ar` dynamic feature module (entitlement-gated SplitInstall).
+ * Binds the base [ArController] to the [ArControllerFacade], which loads the real
+ * implementation from the on-demand `:feature_expert_ar` dynamic feature module
+ * via reflection once an entitled user requests it (see ArControllerFacade).
  */
 @Module
 @InstallIn(SingletonComponent::class)
@@ -21,5 +21,5 @@ abstract class ArFeatureModule {
 
     @Binds
     @Singleton
-    abstract fun bindArController(impl: BaseArController): ArController
+    abstract fun bindArController(impl: ArControllerFacade): ArController
 }

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
@@ -337,9 +337,16 @@ class MainViewModel @Inject constructor(
             }
         }
 
-        // Detect ARCore depth capability and store in state
+        // Expert-AR is delivered on demand. Once the user is entitled, ensure the
+        // `:feature_expert_ar` split is installed/loaded, then probe ARCore
+        // capability through it. Until then the controller is a no-op (capability
+        // NONE), so the AR/scan UI never composes for free users.
         viewModelScope.launch {
-            onEvent(MainScreenEvent.DepthCapabilityDetected(arController.probeCapability()))
+            entitlementRepository.entitlement.collect { entitlement ->
+                if (entitlement.active && arController.ensureLoaded()) {
+                    onEvent(MainScreenEvent.DepthCapabilityDetected(arController.probeCapability()))
+                }
+            }
         }
 
         viewModelScope.launch {

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/ScanStep.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/ScanStep.kt
@@ -1,0 +1,16 @@
+package com.hereliesaz.cuedetat.ui.composables.tablescan
+
+/**
+ * Phases of the table-scan flow.
+ *
+ * Lives in the base (not the on-demand `:feature_expert_ar` module) because
+ * [com.hereliesaz.cuedetat.data.TableScanRepository] persists/restores it, and
+ * the base must not depend on the AR module. The module's TableScanViewModel
+ * imports this type.
+ */
+enum class ScanStep {
+    FELT_CAPTURE,
+    CORNER_QUAD,
+    POCKET_GUIDE,
+    AUTO_READY
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,4 +133,5 @@
 
     <!-- Dynamic feature delivery -->
     <string name="mlmodel_feature_title">Pool vision model</string>
+    <string name="expert_ar_feature_title">Expert AR table scan</string>
 </resources>

--- a/app/src/play/java/com/hereliesaz/cuedetat/delivery/PlayArFeatureDelivery.kt
+++ b/app/src/play/java/com/hereliesaz/cuedetat/delivery/PlayArFeatureDelivery.kt
@@ -1,0 +1,89 @@
+// FILE: app/src/play/java/com/hereliesaz/cuedetat/delivery/PlayArFeatureDelivery.kt
+
+package com.hereliesaz.cuedetat.delivery
+
+import android.content.Context
+import android.util.Log
+import com.google.android.play.core.splitcompat.SplitCompat
+import com.google.android.play.core.splitinstall.SplitInstallManager
+import com.google.android.play.core.splitinstall.SplitInstallManagerFactory
+import com.google.android.play.core.splitinstall.SplitInstallRequest
+import com.google.android.play.core.splitinstall.SplitInstallStateUpdatedListener
+import com.google.android.play.core.splitinstall.model.SplitInstallSessionStatus
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.suspendCancellableCoroutine
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+
+/**
+ * Play-flavor [ArFeatureDelivery]. The Expert-AR code + ARCore ship in the
+ * `:feature_expert_ar` on-demand dynamic feature, so the base AAB stays smaller
+ * and free users never download ARCore. This requests the split via Play Feature
+ * Delivery and installs SplitCompat so the freshly installed split's classes
+ * become loadable (for the facade's reflection) without an app restart.
+ */
+@Singleton
+class PlayArFeatureDelivery @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : ArFeatureDelivery {
+
+    private val manager: SplitInstallManager by lazy { SplitInstallManagerFactory.create(context) }
+
+    override val isInstalled: Boolean
+        get() = manager.installedModules.contains(MODULE_NAME)
+
+    override suspend fun ensureInstalled(): Boolean {
+        if (isInstalled) {
+            runCatching { SplitCompat.install(context) }
+            return true
+        }
+        return suspendCancellableCoroutine { cont ->
+            val request = SplitInstallRequest.newBuilder().addModule(MODULE_NAME).build()
+            var mySessionId: Int? = null
+            val listener = object : SplitInstallStateUpdatedListener {
+                override fun onStateUpdate(state: com.google.android.play.core.splitinstall.SplitInstallSessionState) {
+                    if (mySessionId != null && state.sessionId() != mySessionId) return
+                    if (!state.moduleNames().contains(MODULE_NAME)) return
+                    when (state.status()) {
+                        SplitInstallSessionStatus.INSTALLED -> {
+                            manager.unregisterListener(this)
+                            runCatching { SplitCompat.install(context) }
+                            if (cont.isActive) cont.resume(true)
+                        }
+
+                        SplitInstallSessionStatus.FAILED,
+                        SplitInstallSessionStatus.CANCELED -> {
+                            Log.w(TAG, "Expert-AR split install ended: ${state.status()}")
+                            manager.unregisterListener(this)
+                            if (cont.isActive) cont.resume(false)
+                        }
+
+                        else -> { /* PENDING / DOWNLOADING / INSTALLING — keep waiting */ }
+                    }
+                }
+            }
+            manager.registerListener(listener)
+            try {
+                manager.startInstall(request)
+                    .addOnSuccessListener { id -> mySessionId = id }
+                    .addOnFailureListener { e ->
+                        Log.e(TAG, "Expert-AR split install failed to start", e)
+                        runCatching { manager.unregisterListener(listener) }
+                        if (cont.isActive) cont.resume(false)
+                    }
+            } catch (t: Throwable) {
+                Log.e(TAG, "Expert-AR split install threw on start", t)
+                runCatching { manager.unregisterListener(listener) }
+                if (cont.isActive) cont.resume(false)
+            }
+            cont.invokeOnCancellation { runCatching { manager.unregisterListener(listener) } }
+        }
+    }
+
+    companion object {
+        private const val TAG = "PlayArFeatureDelivery"
+        // Matches the Gradle module name in settings.gradle (":feature_expert_ar").
+        private const val MODULE_NAME = "feature_expert_ar"
+    }
+}

--- a/app/src/play/java/com/hereliesaz/cuedetat/di/PlayDeliveryModule.kt
+++ b/app/src/play/java/com/hereliesaz/cuedetat/di/PlayDeliveryModule.kt
@@ -2,7 +2,9 @@
 
 package com.hereliesaz.cuedetat.di
 
+import com.hereliesaz.cuedetat.delivery.ArFeatureDelivery
 import com.hereliesaz.cuedetat.delivery.ModelDelivery
+import com.hereliesaz.cuedetat.delivery.PlayArFeatureDelivery
 import com.hereliesaz.cuedetat.delivery.PlayModelDelivery
 import dagger.Binds
 import dagger.Module
@@ -10,7 +12,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
-/** Binds the on-demand Play Feature Delivery model delivery for Play builds. */
+/** Binds the on-demand Play Feature Delivery deliveries (model + Expert-AR) for Play builds. */
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class PlayDeliveryModule {
@@ -18,4 +20,8 @@ abstract class PlayDeliveryModule {
     @Binds
     @Singleton
     abstract fun bindModelDelivery(impl: PlayModelDelivery): ModelDelivery
+
+    @Binds
+    @Singleton
+    abstract fun bindArFeatureDelivery(impl: PlayArFeatureDelivery): ArFeatureDelivery
 }

--- a/feature_expert_ar/build.gradle.kts
+++ b/feature_expert_ar/build.gradle.kts
@@ -1,0 +1,74 @@
+// On-demand dynamic feature module: carries the Expert-only ARCore table-scan
+// flow (ArTableSession / ArFrameProcessor / ArCoreBackground / TableScanScreen /
+// TableScanViewModel / TableScanAnalyzer + ArControllerImpl) AND the ARCore
+// dependency out of the base install.
+//
+// Unlike :feature_mlmodel (asset-only), this module ships Kotlin + Compose code.
+// The base (:app) never references these classes at compile time — it talks to
+// the `ArController` interface and loads `ArControllerImpl` via reflection after
+// the split installs (see ArControllerFacade / PlayArFeatureDelivery). Delivery
+// is entitlement-gated: the split is only requested for paid / trial users.
+//
+// The base uses a `distribution` flavor dimension (play/foss), so this module
+// must declare the same dimension/flavors — otherwise `implementation(project(":app"))`
+// is ambiguous. The `foss` flavor never consumes a split (standalone FOSS APKs
+// have no Play split channel); foss bundles this module's sources directly via a
+// java.srcDir in app/build.gradle.kts, with ARCore added as fossImplementation.
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.android.dynamic.feature)
+    alias(libs.plugins.kotlin.compose)
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_21)
+    }
+}
+
+android {
+    namespace = "com.hereliesaz.cuedetat.feature.expert.ar"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 29
+    }
+
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("play") { dimension = "distribution" }
+        create("foss") { dimension = "distribution" }
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+}
+
+dependencies {
+    implementation(project(":app"))
+
+    // ARCore now lives here — removed from the base `play` flavor.
+    implementation(libs.core)
+
+    // Compose: the module ships TableScanScreen / ArCoreBackground composables.
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.ui)
+    implementation(libs.androidx.ui.graphics)
+    implementation(libs.androidx.compose.material3)
+
+    // CameraX (TableScanAnalyzer) + OpenCV (felt / edge geometry).
+    implementation(libs.bundles.camera)
+    implementation(libs.opencv)
+
+    implementation(libs.kotlinx.coroutines.android)
+
+    // Hilt runtime only (EntryPointAccessors) — no Hilt codegen in this module.
+    implementation(libs.hilt.android)
+}

--- a/feature_expert_ar/src/main/AndroidManifest.xml
+++ b/feature_expert_ar/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:dist="http://schemas.android.com/apk/distribution">
+
+    <!--
+      On-demand delivery: the Expert-AR split is NOT installed with the base app.
+      The base requests it at runtime via SplitInstallManager (PlayArFeatureDelivery),
+      gated on entitlement, the first time an entitled user enters Expert AR.
+
+      dist:fusing include="true" keeps the module available in fused/standalone
+      APKs (universal APK / bundletool standalone) so non-Play distributions of
+      the bundle still contain the AR flow.
+    -->
+    <dist:module
+        dist:instant="false"
+        dist:title="@string/expert_ar_feature_title">
+        <dist:delivery>
+            <dist:on-demand />
+        </dist:delivery>
+        <dist:fusing dist:include="true" />
+    </dist:module>
+
+    <application />
+</manifest>

--- a/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/ArBackgroundRenderer.kt
+++ b/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/ArBackgroundRenderer.kt
@@ -1,4 +1,4 @@
-package com.hereliesaz.cuedetat.data
+package com.hereliesaz.cuedetat.feature.expert.ar
 
 import android.opengl.GLES11Ext
 import android.opengl.GLES20

--- a/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/ArControllerImpl.kt
+++ b/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/ArControllerImpl.kt
@@ -1,37 +1,44 @@
-// FILE: app/src/main/java/com/hereliesaz/cuedetat/arfeature/BaseArController.kt
+package com.hereliesaz.cuedetat.feature.expert.ar
 
-package com.hereliesaz.cuedetat.arfeature
-
+import android.content.Context
 import androidx.camera.core.ImageAnalysis
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.hereliesaz.cuedetat.data.ArFrameProcessor
-import com.hereliesaz.cuedetat.data.ArTableSession
+import com.hereliesaz.cuedetat.arfeature.ArController
+import com.hereliesaz.cuedetat.arfeature.ArFeatureEntryPoint
 import com.hereliesaz.cuedetat.domain.CueDetatState
 import com.hereliesaz.cuedetat.domain.DepthCapability
 import com.hereliesaz.cuedetat.domain.MainScreenEvent
 import com.hereliesaz.cuedetat.domain.TableFrameHomography
-import com.hereliesaz.cuedetat.ui.composables.ArCoreBackground
-import com.hereliesaz.cuedetat.ui.composables.tablescan.TableScanAnalyzer
-import com.hereliesaz.cuedetat.ui.composables.tablescan.TableScanScreen
-import com.hereliesaz.cuedetat.ui.composables.tablescan.TableScanViewModel
-import javax.inject.Inject
-import javax.inject.Singleton
+import dagger.hilt.android.EntryPointAccessors
 
 /**
- * In-base [ArController] implementation. Wraps the existing AR singletons so the
- * rest of the base talks only to the [ArController] interface. Step 2 of the
- * extraction replaces this binding with a reflection-loaded implementation that
- * lives in the on-demand `:feature_expert_ar` module.
+ * The on-demand-module implementation of the base [ArController] interface.
+ *
+ * Instantiated reflectively by ArControllerFacade once the `:feature_expert_ar`
+ * split is installed (play) or compiled in (foss). It owns the AR singletons and
+ * the scan controller, building them manually — Hilt does not extend into a
+ * dynamic feature module, so base dependencies are pulled through the
+ * [ArFeatureEntryPoint] Hilt entry point instead of constructor injection.
+ *
+ * Must expose a single public constructor taking a [Context] (that is the
+ * contract the facade's reflection relies on).
  */
-@Singleton
-class BaseArController @Inject constructor(
-    private val arTableSession: ArTableSession,
-    private val arFrameProcessor: ArFrameProcessor,
-    private val tableScanViewModel: TableScanViewModel,
-) : ArController {
+@Suppress("unused")
+class ArControllerImpl(context: Context) : ArController {
 
-    // Single shared analyzer instance wrapping the scan controller's callbacks.
+    private val appContext = context.applicationContext
+    private val deps = EntryPointAccessors.fromApplication(appContext, ArFeatureEntryPoint::class.java)
+
+    private val arTableSession = ArTableSession(appContext)
+    private val arFrameProcessor = ArFrameProcessor(deps.visionRepository())
+    private val tableScanViewModel = TableScanViewModel(
+        deps.tableScanRepository(),
+        deps.pocketDetector(),
+        arTableSession,
+        arFrameProcessor,
+    )
+
     private val analyzer: ImageAnalysis.Analyzer by lazy {
         TableScanAnalyzer(
             tableScanViewModel::onFrame,
@@ -43,7 +50,6 @@ class BaseArController @Inject constructor(
 
     override fun probeCapability(): DepthCapability =
         if (arTableSession.isArCoreAvailable()) {
-            // Probe depth support by creating (and immediately closing) a test session.
             val testSession = arTableSession.createSession()
             val cap = arTableSession.capability
             if (testSession != null) arTableSession.close()
@@ -57,7 +63,6 @@ class BaseArController @Inject constructor(
     }
 
     override fun setTableZOffsetLogical(tableZOffsetLogical: Float) {
-        // tableZOffset is in logical units; convert to metres for the AR plane lift.
         arTableSession.setTableHeightMeters(
             tableZOffsetLogical / TableFrameHomography.LOGICAL_UNITS_PER_METER
         )

--- a/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/ArCoreBackground.kt
+++ b/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/ArCoreBackground.kt
@@ -1,4 +1,4 @@
-package com.hereliesaz.cuedetat.ui.composables
+package com.hereliesaz.cuedetat.feature.expert.ar
 
 import android.opengl.GLSurfaceView
 import android.util.Log
@@ -14,9 +14,6 @@ import androidx.lifecycle.LifecycleOwner
 import com.google.ar.core.Frame
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
-import com.hereliesaz.cuedetat.data.ArBackgroundRenderer
-import com.hereliesaz.cuedetat.data.ArFrameProcessor
-import com.hereliesaz.cuedetat.data.ArTableSession
 import com.hereliesaz.cuedetat.domain.MainScreenEvent
 import javax.microedition.khronos.egl.EGLConfig
 import javax.microedition.khronos.opengles.GL10

--- a/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/ArFrameProcessor.kt
+++ b/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/ArFrameProcessor.kt
@@ -1,17 +1,15 @@
-// app/src/main/java/com/hereliesaz/cuedetat/data/ArFrameProcessor.kt
-package com.hereliesaz.cuedetat.data
+package com.hereliesaz.cuedetat.feature.expert.ar
 
 import android.graphics.Color
 import android.media.Image
 import com.google.ar.core.Frame
+import com.hereliesaz.cuedetat.data.VisionRepository
 import com.hereliesaz.cuedetat.domain.CueDetatState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * Bridges ARCore frames to [VisionRepository] and samples the felt colour from the AR camera image.
@@ -25,8 +23,8 @@ import javax.inject.Singleton
  * [updateUiState] is called from the main thread; [processFrame] from the GL thread. The
  * [AtomicReference]/[StateFlow] hand-offs keep a consistent snapshot without blocking either thread.
  */
-@Singleton
-class ArFrameProcessor @Inject constructor(
+/** Manually constructed by ArControllerImpl (lives in the on-demand module; no Hilt here). */
+class ArFrameProcessor(
     private val visionRepository: VisionRepository,
 ) {
     private val stateRef = AtomicReference<CueDetatState?>(null)

--- a/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/ArTableSession.kt
+++ b/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/ArTableSession.kt
@@ -1,4 +1,4 @@
-package com.hereliesaz.cuedetat.data
+package com.hereliesaz.cuedetat.feature.expert.ar
 
 import android.content.Context
 import android.graphics.Matrix
@@ -14,13 +14,10 @@ import com.hereliesaz.cuedetat.domain.DepthCapability
 import com.hereliesaz.cuedetat.domain.TableFrameHomography
 import com.hereliesaz.cuedetat.domain.TableFrameHomography.Pt
 import com.hereliesaz.cuedetat.domain.TableFrameHomography.Vec3
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.util.concurrent.atomic.AtomicBoolean
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlin.math.atan2
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -45,9 +42,9 @@ data class CameraAbovePlane(val pitchDegrees: Float, val heightM: Float)
  * which is the only mutator of [anchors] and [orderedAnchors]. The exposed [StateFlow]s are
  * updated from the GL thread and observed on the main thread.
  */
-@Singleton
-class ArTableSession @Inject constructor(
-    @ApplicationContext private val context: Context,
+/** Manually constructed by ArControllerImpl (lives in the on-demand module; no Hilt here). */
+class ArTableSession(
+    private val context: Context,
 ) {
     private var session: Session? = null
     private var tableAnchor: Anchor? = null

--- a/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/TableScanAnalyzer.kt
+++ b/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/TableScanAnalyzer.kt
@@ -1,5 +1,5 @@
 // app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanAnalyzer.kt
-package com.hereliesaz.cuedetat.ui.composables.tablescan
+package com.hereliesaz.cuedetat.feature.expert.ar
 
 import android.graphics.Bitmap
 import android.graphics.PointF
@@ -7,6 +7,7 @@ import android.util.Log
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
 import com.hereliesaz.cuedetat.BuildConfig
+import com.hereliesaz.cuedetat.ui.composables.tablescan.PocketDetector
 import org.opencv.android.Utils
 import org.opencv.core.Core
 import org.opencv.core.Mat

--- a/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/TableScanScreen.kt
+++ b/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/TableScanScreen.kt
@@ -1,5 +1,5 @@
 // app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanScreen.kt
-package com.hereliesaz.cuedetat.ui.composables.tablescan
+package com.hereliesaz.cuedetat.feature.expert.ar
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
@@ -54,6 +54,7 @@ import android.view.HapticFeedbackConstants
 import com.hereliesaz.cuedetat.domain.CueDetatState
 import com.hereliesaz.cuedetat.domain.MainScreenEvent
 import com.hereliesaz.cuedetat.domain.PocketId
+import com.hereliesaz.cuedetat.ui.composables.tablescan.ScanStep
 import kotlinx.coroutines.delay
 
 /**

--- a/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/TableScanViewModel.kt
+++ b/feature_expert_ar/src/main/java/com/hereliesaz/cuedetat/feature/expert/ar/TableScanViewModel.kt
@@ -1,9 +1,11 @@
 // app/src/main/java/com/hereliesaz/cuedetat/ui/composables/tablescan/TableScanViewModel.kt
-package com.hereliesaz.cuedetat.ui.composables.tablescan
+package com.hereliesaz.cuedetat.feature.expert.ar
 
 import android.graphics.Matrix
 import android.graphics.PointF
 import com.hereliesaz.cuedetat.data.TableScanRepository
+import com.hereliesaz.cuedetat.ui.composables.tablescan.PocketDetector
+import com.hereliesaz.cuedetat.ui.composables.tablescan.ScanStep
 import com.hereliesaz.cuedetat.domain.MainScreenEvent
 import com.hereliesaz.cuedetat.domain.PocketCluster
 import com.hereliesaz.cuedetat.domain.PocketId
@@ -30,8 +32,6 @@ import org.opencv.calib3d.Calib3d
 import org.opencv.core.Core
 import org.opencv.core.MatOfPoint2f
 import org.opencv.core.Point
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlin.math.sqrt
 
 /** Min observations per cluster before geometry fitting is attempted. */
@@ -40,13 +40,6 @@ private const val MIN_OBSERVATIONS_TO_FIT = 3
 /** Max distance (logical inches) to merge a new detection into an existing cluster. */
 private const val CLUSTER_MERGE_DISTANCE = 3.0f
 
-enum class ScanStep {
-    FELT_CAPTURE,
-    CORNER_QUAD,
-    POCKET_GUIDE,
-    AUTO_READY
-}
-
 /**
  * Drives the table-scan flow. Formerly a @HiltViewModel; now an app-scoped
  * @Singleton owned by the AR controller, so it can be relocated into the
@@ -54,12 +47,11 @@ enum class ScanStep {
  * hiltViewModel() are unavailable). Lifecycle is the application's; [scope]
  * replaces the old scope.
  */
-@Singleton
-class TableScanViewModel @Inject constructor(
+class TableScanViewModel(
     private val tableScanRepository: TableScanRepository,
     val pocketDetector: PocketDetector,
-    private val arTableSession: com.hereliesaz.cuedetat.data.ArTableSession,
-    private val arFrameProcessor: com.hereliesaz.cuedetat.data.ArFrameProcessor,
+    private val arTableSession: ArTableSession,
+    private val arFrameProcessor: ArFrameProcessor,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -81,3 +81,9 @@ include(":app")
 // bundles the same asset directly (see app/build.gradle.kts), since standalone
 // FOSS APKs have no Play split-install channel.
 include(":feature_mlmodel")
+// On-demand dynamic feature module carrying the Expert-only ARCore table-scan
+// flow + the ARCore dependency. Delivered via Play Feature Delivery for the
+// `play` AAB (entitlement-gated); the `foss` flavor compiles the module's
+// sources directly in (see app/build.gradle.kts), since standalone FOSS APKs
+// have no Play split-install channel.
+include(":feature_expert_ar")


### PR DESCRIPTION
## What

Moves the Expert-only ARCore table-scan flow — and the ARCore dependency itself — out of the base install into a new **on-demand** dynamic feature module, `:feature_expert_ar`, delivered only to **entitled (paid / trial)** users. This builds on the `ArController` seam already merged via #236.

## How

**The boundary (already on `main` from #236):** the base talks only to the `ArController` interface; nothing in the base references the AR/scan classes or ARCore directly.

**This PR (step 2b) — the actual move:**
- Relocates 8 classes into the module: `ArTableSession`, `ArFrameProcessor`, `ArBackgroundRenderer`, `ArCoreBackground`, `TableScanScreen`, `TableScanAnalyzer`, `TableScanViewModel`, + new `ArControllerImpl`.
- Moves the `com.google.ar:core` dependency into the module; the base `play` AAB no longer carries ARCore.
- **Entitlement-gated delivery:** `ArControllerFacade` (the base-bound `ArController`) starts as `NoOpArController`. Only when `entitlement.active` does it install the split (`ArFeatureDelivery`) and reflectively load `ArControllerImpl`, swapping it in via a Compose `mutableStateOf` so the AR/scan surfaces recompose onto the real implementation. Free users never download or run the AR code.
- **Hilt across the boundary:** Hilt does not extend into dynamic feature modules, so the module pulls its base singletons (`VisionRepository`, `TableScanRepository`, `PocketDetector`) through the `ArFeatureEntryPoint` `@EntryPoint` and constructs the AR objects manually.
- **Flavors:** `play` fetches the split on demand (`PlayArFeatureDelivery` / `SplitInstall`); `foss` compiles the module's sources into the APK via a `java.srcDir` with ARCore as `fossImplementation` (standalone FOSS APKs have no Play split channel) — mirroring the existing `:feature_mlmodel` pattern.
- `ScanStep` stays in the base package (it's persisted by `TableScanRepository`) and is imported by the module.

## Verification

- **CI:** compile/assembly only (both flavors + the module).
- ⚠️ **Needs a device:** the Play on-demand split install path and the live ARCore session/scan cannot be verified in CI. The facade degrades to a no-op if the split fails to load, so a failed install leaves the rest of the app unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019zU9hN7wMhh44bjzw49ov3)_