### PR TITLE
Expert-AR: lazy on-demand load + download progress / retry UI

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/domain/ArModuleState.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/domain/ArModuleState.kt
@@ -1,0 +1,22 @@
+package com.hereliesaz.cuedetat.domain
+
+/**
+ * Lifecycle of the on-demand `:feature_expert_ar` dynamic feature module from the
+ * UI's point of view. Distinct from [DepthCapability] (which describes the
+ * device's ARCore support, known only *after* the module loads): this tracks the
+ * download/install of the module itself so the UI can show progress and offer a
+ * retry.
+ *
+ *  - [IDLE]    — not requested yet (free users, or expert users who haven't
+ *                entered AR). The module is never fetched in this state.
+ *  - [LOADING] — the split is downloading / installing, or the impl is being
+ *                loaded. Show a "preparing" overlay.
+ *  - [READY]   — the module is installed and its implementation is loaded.
+ *  - [FAILED]  — the install or load failed; the UI offers a retry.
+ */
+enum class ArModuleState {
+    IDLE,
+    LOADING,
+    READY,
+    FAILED,
+}

--- a/app/src/main/java/com/hereliesaz/cuedetat/domain/StateReducer.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/domain/StateReducer.kt
@@ -73,7 +73,9 @@ fun stateReducer(
         is MainScreenEvent.UpdateArPose, is MainScreenEvent.UpdateTableScanClusters,
         is MainScreenEvent.DepthPlaneUpdated, is MainScreenEvent.ArCameraPoseUpdated,
         is MainScreenEvent.DepthCapabilityDetected, is MainScreenEvent.ArTrackingLost,
-        is MainScreenEvent.ArTableMatrixUpdated, is MainScreenEvent.ArCornerCaptured ->
+        is MainScreenEvent.ArTableMatrixUpdated, is MainScreenEvent.ArCornerCaptured,
+        is MainScreenEvent.ArModuleLoadStarted, is MainScreenEvent.ArModuleLoadSucceeded,
+        is MainScreenEvent.ArModuleLoadFailed ->
             reduceControlAction(currentState, action)
 
         // --- COMPUTER VISION DATA ---

--- a/app/src/main/java/com/hereliesaz/cuedetat/domain/UiModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/domain/UiModel.kt
@@ -140,6 +140,10 @@ data class CueDetatState(
     // capture-feedback line from the last captured pocket to the centre reticle.
     @Transient val arCapturedCorners: List<PointF> = emptyList(),
     val depthCapability: DepthCapability = DepthCapability.NONE,
+    // Download/load lifecycle of the on-demand Expert-AR module. Transient: it is
+    // runtime-only and must not survive process death (a LOADING snapshot would
+    // be stale on restart).
+    @Transient val arModuleState: ArModuleState = ArModuleState.IDLE,
     val lockedHsvColor: FloatArray? = null,
     val lockedHsvStdDev: FloatArray? = null,
     val showAdvancedOptionsDialog: Boolean = false,
@@ -325,6 +329,13 @@ sealed class MainScreenEvent {
         val updatedClusters: List<PocketCluster>
     ) : MainScreenEvent()
     object ToggleTableScanScreen : MainScreenEvent()
+
+    // On-demand Expert-AR module delivery (see ArControllerFacade / MainViewModel).
+    object ArModuleLoadStarted : MainScreenEvent()
+    object ArModuleLoadSucceeded : MainScreenEvent()
+    object ArModuleLoadFailed : MainScreenEvent()
+    /** User tapped "Retry" on the download-failed overlay. */
+    object RetryArModuleLoad : MainScreenEvent()
 
     // Depth / ARCore events
     data class DepthPlaneUpdated(val plane: DepthPlane) : MainScreenEvent()

--- a/app/src/main/java/com/hereliesaz/cuedetat/domain/reducers/ControlReducer.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/domain/reducers/ControlReducer.kt
@@ -126,6 +126,15 @@ internal fun reduceControlAction(state: CueDetatState, action: MainScreenEvent):
         is MainScreenEvent.DepthCapabilityDetected ->
             state.copy(depthCapability = action.capability)
 
+        is MainScreenEvent.ArModuleLoadStarted ->
+            state.copy(arModuleState = com.hereliesaz.cuedetat.domain.ArModuleState.LOADING)
+
+        is MainScreenEvent.ArModuleLoadSucceeded ->
+            state.copy(arModuleState = com.hereliesaz.cuedetat.domain.ArModuleState.READY)
+
+        is MainScreenEvent.ArModuleLoadFailed ->
+            state.copy(arModuleState = com.hereliesaz.cuedetat.domain.ArModuleState.FAILED)
+
         is MainScreenEvent.ArTrackingLost -> {
             // The nuclear payload has been disarmed.
             // If reality stutters, we float on the last known matrix rather than burning the world down.

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
@@ -406,7 +406,16 @@ class MainViewModel @Inject constructor(
         if (arModuleLoadJob?.isActive == true) return
         arModuleLoadJob = viewModelScope.launch {
             onEvent(MainScreenEvent.ArModuleLoadStarted)
-            val loaded = runCatching { arController.ensureLoaded() }.getOrDefault(false)
+            // Don't use runCatching: it would swallow CancellationException and
+            // (e.g. on Retry, which cancels this job) post a spurious
+            // ArModuleLoadFailed that races the freshly started load.
+            val loaded = try {
+                arController.ensureLoaded()
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (t: Throwable) {
+                false
+            }
             if (loaded) {
                 onEvent(MainScreenEvent.DepthCapabilityDetected(arController.probeCapability()))
                 onEvent(MainScreenEvent.ArModuleLoadSucceeded)

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/MainViewModel.kt
@@ -16,6 +16,7 @@ import com.hereliesaz.cuedetat.data.TableScanRepository
 import com.hereliesaz.cuedetat.data.UserPreferencesRepository
 import com.hereliesaz.cuedetat.data.VisionAnalyzer
 import com.hereliesaz.cuedetat.data.VisionRepository
+import com.hereliesaz.cuedetat.domain.ArModuleState
 import com.hereliesaz.cuedetat.domain.BallSelectionPhase
 import com.hereliesaz.cuedetat.domain.CameraMode
 import com.hereliesaz.cuedetat.domain.CueDetatState
@@ -186,6 +187,7 @@ class MainViewModel @Inject constructor(
 
     private var experienceModeUpdateJob: Job? = null
     private var saveJob: Job? = null
+    private var arModuleLoadJob: Job? = null
     // Bounded so an unbounded burst (sensors + vision + gestures) cannot grow without limit.
     // High-frequency producers (sensors, vision, AR) are conflated upstream so they
     // contribute at most one in-flight event each.
@@ -337,17 +339,10 @@ class MainViewModel @Inject constructor(
             }
         }
 
-        // Expert-AR is delivered on demand. Once the user is entitled, ensure the
-        // `:feature_expert_ar` split is installed/loaded, then probe ARCore
-        // capability through it. Until then the controller is a no-op (capability
-        // NONE), so the AR/scan UI never composes for free users.
-        viewModelScope.launch {
-            entitlementRepository.entitlement.collect { entitlement ->
-                if (entitlement.active && arController.ensureLoaded()) {
-                    onEvent(MainScreenEvent.DepthCapabilityDetected(arController.probeCapability()))
-                }
-            }
-        }
+        // Expert-AR is delivered on demand and loaded lazily: the split is only
+        // fetched the first time an (already entitled, since AR is expert-only and
+        // paywall-gated) user actually enters the AR camera flow. See the
+        // CycleCameraMode interception in processEvent + ensureArModuleLoaded().
 
         viewModelScope.launch {
             val savedModel = tableScanRepository.load()
@@ -399,9 +394,45 @@ class MainViewModel @Inject constructor(
         eventChannel.trySend(event)
     }
 
+    /**
+     * Fetch + load the on-demand Expert-AR module if it isn't already, driving the
+     * [CueDetatState.arModuleState] lifecycle so the UI can show progress / retry.
+     * Idempotent: a no-op once READY or while a load is already in flight.
+     * `arController.ensureLoaded()` is itself entitlement-gated and installs the
+     * split (play) before reflectively loading the implementation.
+     */
+    private fun ensureArModuleLoaded() {
+        if (_uiState.value.arModuleState == ArModuleState.READY) return
+        if (arModuleLoadJob?.isActive == true) return
+        arModuleLoadJob = viewModelScope.launch {
+            onEvent(MainScreenEvent.ArModuleLoadStarted)
+            val loaded = runCatching { arController.ensureLoaded() }.getOrDefault(false)
+            if (loaded) {
+                onEvent(MainScreenEvent.DepthCapabilityDetected(arController.probeCapability()))
+                onEvent(MainScreenEvent.ArModuleLoadSucceeded)
+            } else {
+                onEvent(MainScreenEvent.ArModuleLoadFailed)
+            }
+        }
+    }
+
     private fun processEvent(event: MainScreenEvent) {
         if (event is MainScreenEvent.ScreenGestureStarted || event is MainScreenEvent.LogicalGestureStarted) {
             warningManager.dismissWarning()
+        }
+
+        // Lazy Expert-AR delivery. Entering the AR camera flow (CycleCameraMode
+        // from OFF) is the trigger to fetch/load the on-demand module; the reducer
+        // still performs the camera-mode transition, and the UI shows a download
+        // overlay while arModuleState == LOADING. Retry re-runs the same load.
+        if (event is MainScreenEvent.CycleCameraMode && _uiState.value.cameraMode == CameraMode.OFF) {
+            ensureArModuleLoaded()
+        }
+        if (event is MainScreenEvent.RetryArModuleLoad) {
+            arModuleLoadJob?.cancel()
+            arModuleLoadJob = null
+            ensureArModuleLoaded()
+            return
         }
 
         if (event is MainScreenEvent.ToggleExperienceModeSelection) {

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/ProtractorScreen.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/ProtractorScreen.kt
@@ -267,6 +267,19 @@ fun ProtractorScreen(
             }
         }
 
+        // --- Onscreen: Expert-AR module download progress / retry overlay ---
+        // Only while in the AR flow, so a lingering FAILED state doesn't show the
+        // overlay after the user has cancelled back out to a non-AR camera mode.
+        onscreen(alignment = Alignment.Center) {
+            if (isOnMain && (uiState.cameraMode == CameraMode.AR_SETUP
+                    || uiState.cameraMode == CameraMode.AR_ACTIVE)) {
+                com.hereliesaz.cuedetat.ui.composables.ArModuleLoadingOverlay(
+                    uiState = uiState,
+                    onEvent = mainViewModel::onEvent,
+                )
+            }
+        }
+
         // --- Onscreen: AR tracking badge (bottom-start, when AR is actively tracking) ---
         onscreen(alignment = Alignment.BottomStart) {
             if (isOnMain && uiState.cameraMode == CameraMode.AR_ACTIVE

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/ArModuleLoadingOverlay.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/ArModuleLoadingOverlay.kt
@@ -1,0 +1,99 @@
+package com.hereliesaz.cuedetat.ui.composables
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.cuedetat.domain.ArModuleState
+import com.hereliesaz.cuedetat.domain.CueDetatState
+import com.hereliesaz.cuedetat.domain.MainScreenEvent
+
+/**
+ * Foreground overlay shown while the on-demand Expert-AR module is being
+ * downloaded/loaded, or after a load failure. Renders nothing in the IDLE/READY
+ * states, so it can be placed unconditionally in the AR overlay layer.
+ *
+ * Driven by [CueDetatState.arModuleState], which MainViewModel advances as it runs
+ * `arController.ensureLoaded()` on first AR entry.
+ */
+@Composable
+fun ArModuleLoadingOverlay(
+    uiState: CueDetatState,
+    onEvent: (MainScreenEvent) -> Unit,
+) {
+    when (uiState.arModuleState) {
+        ArModuleState.LOADING -> {
+            Surface(
+                shape = MaterialTheme.shapes.large,
+                tonalElevation = 6.dp,
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(28.dp), strokeWidth = 3.dp)
+                    Spacer(Modifier.width(16.dp))
+                    Column {
+                        Text(
+                            text = "Preparing Expert AR…",
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        Text(
+                            text = "Downloading the AR table-scan module. This happens once.",
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                }
+            }
+        }
+
+        ArModuleState.FAILED -> {
+            Surface(
+                shape = MaterialTheme.shapes.large,
+                tonalElevation = 6.dp,
+            ) {
+                Column(
+                    modifier = Modifier.padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = "Couldn’t load Expert AR",
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = "The AR module couldn’t be downloaded. Check your connection and try again.",
+                        style = MaterialTheme.typography.bodySmall,
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        TextButton(onClick = { onEvent(MainScreenEvent.CancelArSetup) }) {
+                            Text("Cancel")
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        Button(onClick = { onEvent(MainScreenEvent.RetryArModuleLoad) }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+        }
+
+        ArModuleState.IDLE, ArModuleState.READY -> { /* no overlay */ }
+    }
+}

--- a/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/ArModuleLoadingOverlay.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/ui/composables/ArModuleLoadingOverlay.kt
@@ -1,8 +1,11 @@
 package com.hereliesaz.cuedetat.ui.composables
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -16,6 +19,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.hereliesaz.cuedetat.domain.ArModuleState
@@ -27,6 +32,10 @@ import com.hereliesaz.cuedetat.domain.MainScreenEvent
  * downloaded/loaded, or after a load failure. Renders nothing in the IDLE/READY
  * states, so it can be placed unconditionally in the AR overlay layer.
  *
+ * While visible it draws a full-screen scrim that consumes all pointer input, so
+ * the user can't interact with the scan/AR UI underneath while the module is
+ * preparing or has failed — the only way forward is Retry or Cancel.
+ *
  * Driven by [CueDetatState.arModuleState], which MainViewModel advances as it runs
  * `arController.ensureLoaded()` on first AR entry.
  */
@@ -35,65 +44,83 @@ fun ArModuleLoadingOverlay(
     uiState: CueDetatState,
     onEvent: (MainScreenEvent) -> Unit,
 ) {
-    when (uiState.arModuleState) {
-        ArModuleState.LOADING -> {
-            Surface(
-                shape = MaterialTheme.shapes.large,
-                tonalElevation = 6.dp,
-            ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp),
-                    verticalAlignment = Alignment.CenterVertically,
+    val state = uiState.arModuleState
+    if (state != ArModuleState.LOADING && state != ArModuleState.FAILED) return
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.5f))
+            // Swallow every pointer event so taps/drags don't reach the UI below.
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        awaitPointerEvent().changes.forEach { it.consume() }
+                    }
+                }
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        when (state) {
+            ArModuleState.LOADING -> {
+                Surface(
+                    shape = MaterialTheme.shapes.large,
+                    tonalElevation = 6.dp,
                 ) {
-                    CircularProgressIndicator(modifier = Modifier.size(28.dp), strokeWidth = 3.dp)
-                    Spacer(Modifier.width(16.dp))
-                    Column {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(28.dp), strokeWidth = 3.dp)
+                        Spacer(Modifier.width(16.dp))
+                        Column {
+                            Text(
+                                text = "Preparing Expert AR…",
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                            Text(
+                                text = "Downloading the AR table-scan module. This happens once.",
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                    }
+                }
+            }
+
+            ArModuleState.FAILED -> {
+                Surface(
+                    shape = MaterialTheme.shapes.large,
+                    tonalElevation = 6.dp,
+                ) {
+                    Column(
+                        modifier = Modifier.padding(24.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
                         Text(
-                            text = "Preparing Expert AR…",
+                            text = "Couldn’t load Expert AR",
                             style = MaterialTheme.typography.titleMedium,
                         )
+                        Spacer(Modifier.height(8.dp))
                         Text(
-                            text = "Downloading the AR table-scan module. This happens once.",
+                            text = "The AR module couldn’t be downloaded. Check your connection and try again.",
                             style = MaterialTheme.typography.bodySmall,
+                            textAlign = TextAlign.Center,
                         )
-                    }
-                }
-            }
-        }
-
-        ArModuleState.FAILED -> {
-            Surface(
-                shape = MaterialTheme.shapes.large,
-                tonalElevation = 6.dp,
-            ) {
-                Column(
-                    modifier = Modifier.padding(24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        text = "Couldn’t load Expert AR",
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                    Spacer(Modifier.height(8.dp))
-                    Text(
-                        text = "The AR module couldn’t be downloaded. Check your connection and try again.",
-                        style = MaterialTheme.typography.bodySmall,
-                        textAlign = TextAlign.Center,
-                    )
-                    Spacer(Modifier.height(16.dp))
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        TextButton(onClick = { onEvent(MainScreenEvent.CancelArSetup) }) {
-                            Text("Cancel")
-                        }
-                        Spacer(Modifier.width(8.dp))
-                        Button(onClick = { onEvent(MainScreenEvent.RetryArModuleLoad) }) {
-                            Text("Retry")
+                        Spacer(Modifier.height(16.dp))
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            TextButton(onClick = { onEvent(MainScreenEvent.CancelArSetup) }) {
+                                Text("Cancel")
+                            }
+                            Spacer(Modifier.width(8.dp))
+                            Button(onClick = { onEvent(MainScreenEvent.RetryArModuleLoad) }) {
+                                Text("Retry")
+                            }
                         }
                     }
                 }
             }
-        }
 
-        ArModuleState.IDLE, ArModuleState.READY -> { /* no overlay */ }
+            ArModuleState.IDLE, ArModuleState.READY -> { /* unreachable: early-returned above */ }
+        }
     }
 }


### PR DESCRIPTION
## What

Builds on the merged `:feature_expert_ar` extraction (#244). Two changes:

1. **Trigger: eager → lazy.** The on-demand split is no longer loaded the moment a user becomes entitled. It now loads on **first AR entry** (`CycleCameraMode` from `OFF`, reachable only in paywall-gated EXPERT mode — so the user is already entitled). This makes the split truly on-demand: entitled users who never open AR never download ARCore.

2. **Download UX.** A new overlay shows a *"Preparing Expert AR…"* progress card while the module installs, and an error card with **Retry / Cancel** if it fails.

## How

- **`MainViewModel.ensureArModuleLoaded()`** — runs `arController.ensureLoaded()`, then probes capability; drives the lifecycle via `ArModuleLoad{Started,Succeeded,Failed}` events. Idempotent (no-op once `READY` or while a load is in flight). Triggered by intercepting `CycleCameraMode` (OFF→AR_SETUP) and `RetryArModuleLoad` in `processEvent`.
- **`CueDetatState.arModuleState`** (`IDLE/LOADING/READY/FAILED`, `@Transient`) — handled in `ControlReducer`.
- **`ArModuleLoadingOverlay`** — gated on being in the AR camera flow, so a lingering `FAILED` state doesn't show the overlay after the user cancels back out.

## Why lazy

The whole point of the split is to keep ARCore out of the base install. Eager-on-entitlement downloaded ~the ARCore payload as soon as someone paid, even if they never used AR — undercutting that. Lazy-on-AR-entry, with progress UX to cover the one-time wait, aligns delivery with actual use.

## Verification

- **CI:** compile/assembly + reducer logic.
- ⚠️ **Needs a device:** the actual split download timing and the overlay's appearance during a real Play install can only be confirmed on-device. On unsupported devices the module still loads but `probeCapability()` returns `NONE`, so AR simply doesn't render (pre-existing behavior) and the overlay clears on `READY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019zU9hN7wMhh44bjzw49ov3)_