### PR TITLE
Fix startup NPE when restoring persisted state via Gson

### DIFF
--- a/app/src/main/java/com/hereliesaz/cuedetat/di/AppModule.kt
+++ b/app/src/main/java/com/hereliesaz/cuedetat/di/AppModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.PointF
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.google.gson.InstanceCreator
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonToken
@@ -14,6 +15,7 @@ import com.google.mlkit.vision.objects.defaults.ObjectDetectorOptions
 import com.hereliesaz.cuedetat.BuildConfig
 import com.hereliesaz.cuedetat.data.MergedTFLiteDetector
 import com.hereliesaz.cuedetat.delivery.ModelDelivery
+import com.hereliesaz.cuedetat.domain.CueDetatState
 import com.hereliesaz.cuedetat.network.GithubApi
 import com.hereliesaz.cuedetat.ui.composables.tablescan.PocketDetector
 import dagger.Module
@@ -118,6 +120,19 @@ object AppModule {
     @Singleton
     fun provideGson(): Gson {
         return GsonBuilder()
+            // Gson normally instantiates via Unsafe, which bypasses the Kotlin
+            // constructor entirely: default values AND non-null checks are skipped,
+            // so any field absent from an older persisted JSON (a newly-added field,
+            // or any @Transient field, which Gson never writes) is left as raw null.
+            // That null survives silently in the restored state until the first
+            // .copy(), whose regenerated constructor runs checkNotNullParameter
+            // (R8-lowered to Object.getClass()) and throws an NPE. Seeding a fully
+            // default-constructed instance makes Gson overwrite only the fields
+            // present in the JSON and keep the Kotlin defaults for the rest.
+            .registerTypeAdapter(
+                CueDetatState::class.java,
+                InstanceCreator<CueDetatState> { CueDetatState() }
+            )
             .registerTypeAdapter(PointF::class.java, object : TypeAdapter<PointF>() {
                 override fun write(out: JsonWriter, value: PointF?) {
                     if (value == null) { out.nullValue(); return }

--- a/app/src/test/java/com/hereliesaz/cuedetat/domain/CueDetatStateRestoreTest.kt
+++ b/app/src/test/java/com/hereliesaz/cuedetat/domain/CueDetatStateRestoreTest.kt
@@ -1,0 +1,59 @@
+package com.hereliesaz.cuedetat.domain
+
+import com.hereliesaz.cuedetat.di.AppModule
+import com.hereliesaz.cuedetat.view.state.DistanceUnit
+import com.hereliesaz.cuedetat.view.state.InteractionMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * Regression tests for the persisted-state restore crash.
+ *
+ * Gson instantiates via Unsafe, bypassing the Kotlin constructor's default
+ * values and null-checks. Before the InstanceCreator fix, any non-null field
+ * absent from an older persisted JSON (a newly-added field, or any @Transient
+ * field Gson never writes) deserialized to raw null, and the first .copy() on
+ * the restored state threw NPE via checkNotNullParameter (R8-lowered to
+ * Object.getClass()).
+ */
+class CueDetatStateRestoreTest {
+
+    private val gson = AppModule.provideGson()
+
+    @Test
+    fun oldJsonMissingNonNullFieldsRestoresWithDefaults() {
+        // A minimal, stale persisted snapshot: only a couple of primitive fields,
+        // none of the non-null enum/list/@Transient fields present.
+        val oldJson = """{"viewWidth":1080,"viewHeight":1920}"""
+
+        val restored = gson.fromJson(oldJson, CueDetatState::class.java)
+
+        // Fields present in the JSON are honored...
+        assertEquals(1080, restored.viewWidth)
+        assertEquals(1920, restored.viewHeight)
+        // ...and every absent non-null field falls back to its Kotlin default
+        // instead of being left as null.
+        assertEquals(DistanceUnit.IMPERIAL, restored.distanceUnit)
+        assertEquals(TargetType.SOLIDS, restored.targetType)
+        assertEquals(InteractionMode.NONE, restored.interactionMode)
+        assertEquals(BallSelectionPhase.NONE, restored.ballSelectionPhase)
+        assertNotNull(restored.table)
+        assertNotNull(restored.protractorUnit)
+        assertNotNull(restored.obstacleBalls)
+        assertNotNull(restored.masseImpactPoints)
+    }
+
+    @Test
+    fun copyOnRestoredOldStateDoesNotThrow() {
+        val oldJson = """{"viewWidth":1080,"viewHeight":1920}"""
+        val restored = gson.fromJson(oldJson, CueDetatState::class.java)
+
+        // This is the exact operation that crashed in the field: the first reducer
+        // .copy() runs the real constructor and its non-null checks.
+        val copied = restored.copy(viewWidth = 720)
+
+        assertEquals(720, copied.viewWidth)
+        assertEquals(DistanceUnit.IMPERIAL, copied.distanceUnit)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes an on-launch crash observed in logcat:

```
java.lang.NullPointerException: Attempt to invoke virtual method
'java.lang.Class java.lang.Object.getClass()' on a null object reference
	at com.hereliesaz.cuedetat.domain.CueDetatState.copy-oPICyJk(...)
	at ...invokeSuspend(...)   // Dispatchers.Main.immediate
```

## Root cause

`UserPreferencesRepository.stateFlow` restores state with
`gson.fromJson(json, CueDetatState::class.java)`. Gson instantiates the
object via `Unsafe`, which **bypasses the Kotlin constructor entirely** —
so both the default values and the generated non-null checks are skipped.

As a result, any field that is *absent* from an older persisted JSON is
left as a raw JVM default (`null` for references). This includes:

- newly-added non-null fields not present in the previously-saved JSON, and
- every `@Transient` non-null field (`ballSelectionPhase`, `masseImpactPoints`,
  `arModuleState`, …), which Gson never serializes at all.

The null sits silently in the restored state until the first `.copy()` —
`MainViewModel` does `(savedState ?: CueDetatState()).copy(...)` on launch.
`copy()` runs the real constructor, whose `checkNotNullParameter` is lowered
by R8 to a bare `Object.getClass()` call, producing the NPE above. (The
`copy-oPICyJk` mangling just reflects that the data class has Compose
`Offset` value-class fields — incidental to the bug.)

## Fix

Register a Gson `InstanceCreator` that seeds a fully default-constructed
`CueDetatState()`. Gson's reflective adapter then overwrites only the
fields present in the JSON and keeps the valid Kotlin defaults for the
rest — so no non-null field is ever left null. This resolves the entire
class of "restore old/partial state → crash on copy" bugs, not just the
current offending field.

## Changes

- `di/AppModule.kt`: register `InstanceCreator<CueDetatState> { CueDetatState() }` on the shared Gson.
- `test/.../CueDetatStateRestoreTest.kt`: regression tests that a stale JSON snapshot restores with defaults and that a subsequent `.copy()` does not throw.

## Testing

Could not run the Gradle unit tests in this environment (no Android SDK
present). The added test exercises the exact restore-then-copy path that
crashed and asserts defaults are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNU1ctjEfbqXtSwDGJkJsM)_

## Summary by Sourcery

Prevent null-pointer crashes when restoring persisted CueDetatState from Gson by ensuring defaults are applied to missing fields and adding regression coverage.

Bug Fixes:
- Ensure CueDetatState deserialization uses a default-constructed instance so missing non-null or transient fields retain their Kotlin defaults instead of becoming null, avoiding NPEs on copy().

Enhancements:
- Centralize CueDetatState Gson configuration in AppModule by registering a type adapter with an InstanceCreator that seeds a default state instance.

Tests:
- Add CueDetatStateRestoreTest to verify stale JSON restores with default values and that performing copy() on restored state no longer throws.