### PR TITLE
Fix bundlePlayRelease: credential env names, mock-device scope, JDK 21

### DIFF
--- a/.github/workflows/android_debug_apk_release.yml
+++ b/.github/workflows/android_debug_apk_release.yml
@@ -75,10 +75,10 @@ jobs:
           # Clean up temporary files
           rm private_key.pem certificate_chain.crt keystore.p12
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -83,10 +83,10 @@ jobs:
 
           rm private_key.pem certificate_chain.crt keystore.p12
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/play_publish.yml
+++ b/.github/workflows/play_publish.yml
@@ -88,10 +88,10 @@ jobs:
           rm private_key.pem certificate_chain.crt keystore.p12
           echo "Keystore generated at app/keystore.jks"
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -408,12 +408,15 @@ dependencies {
     // audience a FOSS flavor exists for.
     "playImplementation"(libs.mwdat.core)
     "playImplementation"(libs.mwdat.camera)
-    // Note: flavour+buildType configurations ("playDebugImplementation") are not
-    // available at this point in configuration, so the mock device rides on the
-    // flavour configuration instead. It is debug tooling and unreferenced in
-    // release, so R8 strips it; the property that matters is preserved -- the
-    // foss flavour never needs the credentialed registry.
-    "playImplementation"(libs.mwdat.mockdevice)
+    // The mock device is debug tooling and must stay off the release classpath.
+    // "R8 will strip it" is not an argument for widening the scope: shrinking runs
+    // long after resolution, so bundlePlayRelease would still have to fetch the
+    // artifact from the credentialed registry before it could throw it away --
+    // which is exactly how it broke.
+    //
+    // The flavour+buildType configuration does not exist yet while this block is
+    // evaluated (AGP creates it once the android DSL is finalised), so the
+    // narrowest correct scope has to be applied afterwards. See below.
 
     // Wear OS Data Layer
     implementation(libs.play.services.wearable)
@@ -447,5 +450,18 @@ configurations.all {
             useVersion(libs.versions.bouncycastle.get())
             because("Force-upgrade Bouncy Castle modules to fix vulnerabilities and ensure version alignment")
         }
+    }
+}
+
+// Meta Wearables mock device: play + debug only.
+//
+// `playDebugImplementation` is created by AGP after the android DSL is
+// finalised, so it cannot be named inside the dependencies { } block above.
+// Registering it here keeps the artifact -- which resolves only from the
+// credentialed GitHub Packages registry -- off both playReleaseRuntimeClasspath
+// and every foss classpath.
+afterEvaluate {
+    dependencies {
+        add("playDebugImplementation", libs.mwdat.mockdevice)
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,12 +35,30 @@ dependencyResolutionManagement {
                 val file = settingsDir.resolve("local.properties")
                 if (file.exists()) file.inputStream().use { load(it) }
             }
+            // Credential lookup order matters, and the env-var names are not
+            // interchangeable. GitHub Actions sets GITHUB_ACTOR automatically but
+            // never exports GITHUB_TOKEN as an env var, and a workflow's built-in
+            // GITHUB_TOKEN cannot read another org's packages anyway. Every
+            // workflow in .github/workflows therefore passes a PAT as GH_TOKEN
+            // with GH_ACTOR alongside it -- those are the names that must be read
+            // here. Dropping them yields a blank password and a 401 from
+            // maven.pkg.github.com that reads like a permissions problem.
             val ghUser = providers.gradleProperty("gh_user")
+                .orElse(providers.environmentVariable("GH_ACTOR"))
                 .orElse(providers.environmentVariable("GITHUB_ACTOR"))
                 .orNull ?: localProps.getProperty("gh_user")
             val ghToken = providers.gradleProperty("gh_token")
+                .orElse(providers.environmentVariable("GH_TOKEN"))
                 .orElse(providers.environmentVariable("GITHUB_TOKEN"))
                 .orNull ?: localProps.getProperty("gh_token")
+
+            if (ghUser.isNullOrBlank() || ghToken.isNullOrBlank()) {
+                logger.warn(
+                    "GitHubPackages credentials are missing or blank. Set gh_user and " +
+                        "gh_token in local.properties, or export GH_ACTOR and GH_TOKEN. " +
+                        "The foss flavor builds without them; the play flavor cannot."
+                )
+            }
 
             credentials {
                 username = ghUser ?: ""


### PR DESCRIPTION
`bundlePlayRelease` failed resolving all three `com.meta.wearable` artifacts with `401 Unauthorized`. Three separate defects, two of them regressions from the rebuild pass in #253.

## 1. GitHub Packages credentials were never sent

The rebuild collapsed the credential lookup in `settings.gradle.kts` to `GITHUB_ACTOR` / `GITHUB_TOKEN`. Those names are wrong for this project:

- GitHub Actions sets `GITHUB_ACTOR` automatically, but **never exports `GITHUB_TOKEN` as an environment variable**.
- A workflow's built-in `GITHUB_TOKEN` cannot read another organisation's packages in any case.

Every workflow in `.github/workflows` passes a PAT as `GH_TOKEN` with `GH_ACTOR` alongside it. So the username resolved and the password was blank — producing a 401 that reads like a permissions problem rather than a missing lookup.

Restores the `GH_ACTOR` / `GH_TOKEN` lookups, and the warning that fires when credentials are absent so the next occurrence is legible in the log.

## 2. The mock device was on the release classpath

`mwdat-mockdevice` was originally `debugImplementation`. It moved to the flavour configuration on the reasoning that R8 would strip it from release builds. That reasoning was wrong: **shrinking runs long after resolution**, so `bundlePlayRelease` had to fetch an artifact it never previously needed from the credentialed registry before it could discard it. One of the three 401s was self-inflicted.

The flavour+buildType configuration does not exist while the `dependencies { }` block is evaluated — AGP creates it once the android DSL is finalised — so the registration moves to `afterEvaluate`.

Verified by probing the declared dependencies of each variant's runtime classpath:

| configuration | declared `com.meta.wearable` deps |
| --- | --- |
| `playReleaseRuntimeClasspath` | `mwdat-camera`, `mwdat-core` |
| `playDebugRuntimeClasspath` | `mwdat-camera`, `mwdat-core`, `mwdat-mockdevice` |
| `fossReleaseRuntimeClasspath` | *(none)* |
| `fossDebugRuntimeClasspath` | *(none)* |

## 3. The Android workflows were still on JDK 17

`app/build.gradle.kts` compiles at source/target 21 with `jvmTarget` 21, but `android_release.yml`, `android_debug_apk_release.yml` and `play_publish.yml` pinned `setup-java` to 17 — which would have failed at compilation had resolution ever succeeded. `release.yml` derives its version by grepping the build files and already resolves to 21, so it is unchanged.

## On the configuration-cache error

The log also reported a configuration-cache serialisation failure against `:app:mergePlayReleaseAssets` (`error writing value of type 'DefaultConfigurableFileCollection'`). That is a consequence of the failed resolution, not an independent problem: `:app:bundleFossRelease` runs the same task graph through `mergeFossReleaseAssets`, R8, packaging and signing, and stores a clean configuration-cache entry.

## Verification

Run locally against an Android SDK:

- `:app:help` configures cleanly (it previously failed with `Configuration with name 'playDebugImplementation' not found`, which is how the `afterEvaluate` requirement was established).
- The credential lookup reads `GH_ACTOR`/`GH_TOKEN` — the warning fires when they are unset and is silent when they are set.
- `:app:compileFossReleaseKotlin` compiles under JDK 21.
- The FOSS release graph runs to its deliberate `bundleFossRelease` guard with no configuration-cache problems.

**Not verified here:** the play resolution itself. It needs the credentialed Meta Wearables registry, which this sandbox cannot reach. If `bundlePlayRelease` still 401s after this, the `GH_TOKEN` secret itself is absent or expired rather than unread.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRVPhNoNiYpg8Miw3DQkEP)_

## Summary by Sourcery

Fix Play release dependency resolution and build compatibility by restoring package credentials, narrowing mock-device scope, and standardizing Android workflows on JDK 21.

Bug Fixes:
- Restore GitHub Packages credential lookup using the workflow-provided GH_ACTOR and GH_TOKEN variables, with a warning when credentials are unavailable.
- Keep the mock-device dependency limited to Play debug builds so Play release builds no longer resolve the credentialed mock artifact.

Enhancements:
- Align Android release, debug APK release, and Play publishing workflows with the project's JDK 21 requirements.

CI:
- Update Android GitHub Actions workflows to use JDK 21.