### PR TITLE
Auto-publish every main build to four Play tracks from one upload

### DIFF
--- a/.github/scripts/play_publish.py
+++ b/.github/scripts/play_publish.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Publish one AAB to several Google Play tracks in a single edit.
+
+Why this exists rather than r0adkll/upload-google-play
+------------------------------------------------------
+The release policy is: internal and alpha go live, open testing (``beta``) and
+production land as drafts a human promotes. That is four tracks with two
+different statuses, off ONE artifact.
+
+The action cannot express it. Its ``tracks`` input is comma-separated but
+``status`` is a single value applied to all of them, so two statuses means two
+invocations -- and each invocation opens its own Play edit and re-uploads the
+bundle, which fails the second time because that version code already exists.
+Its ``existingEditId`` input looks like an escape hatch, but the action exposes
+no edit id as an output, so there is nothing to thread from the first call to
+the second.
+
+The Play Developer API models this natively. An edit is a transaction: upload
+the bundle once, point as many tracks at the resulting version code as you
+like, commit once. That is what this script does, and it is the shape the
+release policy actually has.
+
+Environment
+-----------
+PLAY_SERVICE_ACCOUNT_JSON  Service-account key, as JSON text.
+PLAY_PACKAGE_NAME          Application id.
+PLAY_AAB_PATH              Path to the .aab to upload.
+PLAY_MAPPING_PATH          Optional R8 mapping.txt, uploaded for deobfuscation.
+PLAY_RELEASE_NAME          Optional human-readable release name.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaFileUpload
+
+SCOPE = "https://www.googleapis.com/auth/androidpublisher"
+
+# The release policy, in one place. Order matters only for readability -- every
+# entry in a single edit refers to the same uploaded bundle.
+#
+# Play's track ids do not match the console's labels: "closed testing" is
+# `alpha` and "open testing" is `beta`.
+TRACK_PLAN: list[tuple[str, str]] = [
+    ("internal", "completed"),   # live to internal testers
+    ("alpha", "completed"),      # live to closed testing
+    ("beta", "draft"),           # open testing, awaiting a human
+    ("production", "draft"),     # production, awaiting a human
+]
+
+
+def require(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        sys.exit(f"error: {name} is unset or empty")
+    return value
+
+
+def main() -> int:
+    package_name = require("PLAY_PACKAGE_NAME")
+    aab_path = require("PLAY_AAB_PATH")
+    mapping_path = os.environ.get("PLAY_MAPPING_PATH", "").strip()
+    release_name = os.environ.get("PLAY_RELEASE_NAME", "").strip()
+
+    if not os.path.isfile(aab_path):
+        sys.exit(f"error: no AAB at {aab_path}")
+
+    credentials = service_account.Credentials.from_service_account_info(
+        json.loads(require("PLAY_SERVICE_ACCOUNT_JSON")),
+        scopes=[SCOPE],
+    )
+    service = build(
+        "androidpublisher", "v3", credentials=credentials, cache_discovery=False
+    )
+    edits = service.edits()
+
+    edit_id = edits.insert(packageName=package_name, body={}).execute()["id"]
+    print(f"Opened edit {edit_id}")
+
+    try:
+        # Upload once. Every track below reuses the version code this returns.
+        bundle = edits.bundles().upload(
+            packageName=package_name,
+            editId=edit_id,
+            media_body=MediaFileUpload(
+                aab_path, mimetype="application/octet-stream", resumable=True
+            ),
+        ).execute()
+        version_code = bundle["versionCode"]
+        print(f"Uploaded {aab_path} as versionCode {version_code}")
+
+        if mapping_path and os.path.isfile(mapping_path):
+            edits.deobfuscationfiles().upload(
+                packageName=package_name,
+                editId=edit_id,
+                apkVersionCode=version_code,
+                deobfuscationFileType="proguard",
+                media_body=MediaFileUpload(
+                    mapping_path, mimetype="application/octet-stream"
+                ),
+            ).execute()
+            print(f"Uploaded mapping from {mapping_path}")
+        elif mapping_path:
+            print(f"No mapping file at {mapping_path}; skipping deobfuscation upload")
+
+        for track, status in TRACK_PLAN:
+            release: dict[str, object] = {
+                "versionCodes": [str(version_code)],
+                "status": status,
+            }
+            if release_name:
+                release["name"] = release_name
+            edits.tracks().update(
+                packageName=package_name,
+                editId=edit_id,
+                track=track,
+                body={"releases": [release]},
+            ).execute()
+            print(f"Assigned versionCode {version_code} to {track} ({status})")
+
+        edits.commit(packageName=package_name, editId=edit_id).execute()
+        print(f"Committed edit {edit_id}")
+
+    except Exception:
+        # Leave no half-built edit behind to collide with the next run. Delete is
+        # best-effort: the original failure is what matters, so never let a
+        # cleanup error replace it.
+        try:
+            edits.delete(packageName=package_name, editId=edit_id).execute()
+            print(f"Discarded edit {edit_id}", file=sys.stderr)
+        except HttpError as cleanup_error:
+            print(
+                f"warning: could not discard edit {edit_id}: {cleanup_error}",
+                file=sys.stderr,
+            )
+        raise
+
+    tracks = ", ".join(f"{t} ({s})" for t, s in TRACK_PLAN)
+    print(f"Published versionCode {version_code} to: {tracks}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/play_publish.yml
+++ b/.github/workflows/play_publish.yml
@@ -1,37 +1,35 @@
 name: Play Publish (AAB)
 
-# Builds a signed Android App Bundle of the `play` flavor and (optionally)
-# publishes it to the Google Play Console.
+# Builds a signed Android App Bundle of the `play` flavor and publishes it to
+# the Google Play Console.
 #
-# Safe by default: manual trigger only, internal track, draft status, and
-# publishing OFF (build + upload the .aab as a workflow artifact only). Flip the
-# `publish` input to actually push to Play.
+# Every push to main publishes. One AAB is uploaded once and assigned to four
+# tracks in a single Play edit (see .github/scripts/play_publish.py):
+#
+#   internal    completed  -- live to internal testers
+#   alpha       completed  -- live to closed testing
+#   beta        draft      -- open testing, awaiting a human
+#   production  draft      -- production, awaiting a human
+#
+# Play's track ids do not match the console's labels: "closed testing" is
+# `alpha` and "open testing" is `beta`.
+#
+# A manual run can set `dry_run` to build and upload the .aab as a workflow
+# artifact without touching Play.
 #
 # Signing reuses the same secrets and injected-signing approach as
 # android_release.yml; versioning reuses the -PversionBuild override
 # (git commit count) wired into app/build.gradle.kts.
 
 on:
-  push: 
+  push:
     branches: 'main'
   workflow_dispatch:
     inputs:
-      track:
-        description: 'Play track to publish to'
-        type: choice
-        options: [internal, alpha, beta, production]
-        default: internal
-        required: true
-      status:
-        description: 'Release status on the chosen track'
-        type: choice
-        options: [draft, completed]
-        default: completed
-        required: true
-      publish:
-        description: 'Publish to Play? (off = build + upload the .aab artifact only)'
+      dry_run:
+        description: 'Build the .aab but do NOT publish it to Play'
         type: boolean
-        default: true
+        default: false
         required: true
 
 concurrency:
@@ -116,6 +114,7 @@ jobs:
           echo "package_name=$PKG" >> "$GITHUB_OUTPUT"
 
       - name: Build signed Play AAB
+        id: build
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
@@ -128,6 +127,7 @@ jobs:
         run: |
           BUILD_NUMBER=$(git rev-list --count HEAD)
           echo "versionCode (commit count) = $BUILD_NUMBER"
+          echo "version_code=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
 
           ./gradlew bundlePlayRelease -PversionBuild="$BUILD_NUMBER" --build-cache \
             -Pandroid.injected.signing.store.file="$(pwd)/app/keystore.jks" \
@@ -153,13 +153,27 @@ jobs:
           path: ${{ steps.aab.outputs.aab_path }}
           if-no-files-found: error
 
-      - name: Publish to Google Play
-        if: ${{ github.event.inputs.publish == 'true' }}
-        uses: r0adkll/upload-google-play@v1
+      # r0adkll/upload-google-play cannot express this policy: its `status` is a
+      # single value across all `tracks`, so two statuses would need two
+      # invocations -- two separate Play edits, the second re-uploading a
+      # version code that already exists. Its `existingEditId` input has no
+      # matching output to thread between calls. The API models it directly.
+      - name: Set up Python
+        if: ${{ github.event_name == 'push' || github.event.inputs.dry_run != 'true' }}
+        uses: actions/setup-python@v5
         with:
-          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: ${{ steps.pkg.outputs.package_name }}
-          releaseFiles: app/build/outputs/bundle/playRelease/*.aab
-          track: ${{ github.event.inputs.track }}
-          status: ${{ github.event.inputs.status }}
-          mappingFile: app/build/outputs/mapping/playRelease/mapping.txt
+          python-version: '3.12'
+
+      - name: Install Play publishing dependencies
+        if: ${{ github.event_name == 'push' || github.event.inputs.dry_run != 'true' }}
+        run: pip install --disable-pip-version-check google-api-python-client google-auth
+
+      - name: Publish to Google Play
+        if: ${{ github.event_name == 'push' || github.event.inputs.dry_run != 'true' }}
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          PLAY_PACKAGE_NAME: ${{ steps.pkg.outputs.package_name }}
+          PLAY_AAB_PATH: ${{ steps.aab.outputs.aab_path }}
+          PLAY_MAPPING_PATH: app/build/outputs/mapping/playRelease/mapping.txt
+          PLAY_RELEASE_NAME: ${{ steps.build.outputs.version_code }}
+        run: python .github/scripts/play_publish.py

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ project_backup_full_*
 project_source_only_*
 project_source_scoped_*
 .superpowers/
+
+# ── Python (CI tooling) ──────────────────────────────────────────────────────
+__pycache__/
+*.pyc


### PR DESCRIPTION
Pushes to `main` built a signed AAB and then published **nothing**. The publish step was gated on `github.event.inputs.publish == 'true'`, and that input is empty on a push event, so the condition was never true. The `.aab` was only ever a workflow artifact.

The release policy is now explicit and automatic. One AAB is uploaded once and assigned to four tracks in a single Play edit:

| Track | Status | Meaning |
| --- | --- | --- |
| `internal` | `completed` | live to internal testers |
| `alpha` | `completed` | live to closed testing |
| `beta` | `draft` | open testing, awaiting a human |
| `production` | `draft` | production, awaiting a human |

Play's track ids don't match the console's labels: **"closed testing" is `alpha`** and **"open testing" is `beta`**.

## Why this replaces `r0adkll/upload-google-play`

The action cannot express this policy:

- Its `tracks` input is comma-separated, but `status` is a **single value applied to all of them** — so two statuses means two invocations.
- Each invocation opens its own Play edit and re-uploads the bundle, which fails the second time because that version code already exists.
- Its `existingEditId` input looks like the escape hatch, but the action **publishes no edit id as an output**, so there is nothing to thread from the first call into the second.

The Play Developer API models this natively. An edit is a transaction: upload the bundle once, point as many tracks at the resulting version code as needed, commit once. `.github/scripts/play_publish.py` does exactly that — matching the "upload for internal, then the others reuse that upload" shape — and uploads the R8 mapping for deobfuscated crash reports within the same edit. A failure mid-edit discards the edit rather than leaving a half-built one behind to collide with the next run.

The workflow's `track`/`status`/`publish` inputs are gone; they described a single-track choice that no longer exists. A manual run can set `dry_run` to build and upload the `.aab` artifact without touching Play.

## Verification

Every API method and parameter name was checked against the shipped `androidpublisher` v3 discovery document, and the request bodies against its schemas. Two details a plausible-looking guess gets wrong are confirmed right:

- `TrackRelease.versionCodes` is an array of **strings** (int64 format), not integers.
- `draft` and `completed` are both members of the `status` enum.

The call sequence was exercised end-to-end against a mocked API:

```
edits.insert
edits.bundles.upload                -> versionCode 1429
edits.deobfuscationfiles.upload
edits.tracks.update  internal   {'versionCodes': ['1429'], 'status': 'completed'}
edits.tracks.update  alpha      {'versionCodes': ['1429'], 'status': 'completed'}
edits.tracks.update  beta       {'versionCodes': ['1429'], 'status': 'draft'}
edits.tracks.update  production {'versionCodes': ['1429'], 'status': 'draft'}
edits.commit
```

Asserted: the bundle uploads exactly once; all four tracks reference that one version code; the track/status plan is exactly as above; `commit` is the final call; and a mid-edit failure propagates the original error, discards the edit, and commits nothing.

## Not verified here

**The live Play console.** Whether Play accepts this exact combination — one version code simultaneously live on `internal` and `alpha` while drafted on `beta` and `production` — can only be established against the real service, and this sandbox has no Play credentials. The first push to `main` after merge is the real test.

Worth knowing before merging: this publishes on **every** push to `main`, including pushes that change no app code, since the version code is the commit count.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRVPhNoNiYpg8Miw3DQkEP)_

## Summary by Sourcery

Publish each main-branch build to the configured Google Play tracks through a single transactional release.

New Features:
- Automatically publish every build from main to internal and closed testing while creating drafts for open testing and production.
- Support manual dry runs that produce the AAB artifact without publishing to Google Play.

Bug Fixes:
- Fix main-branch builds that previously never published because publishing depended on an unavailable push-event input.

Enhancements:
- Replace single-track publishing with transactional multi-track Play publishing that uploads the bundle once and reuses its version code across all tracks.
- Upload R8 mapping files during the same Play edit to support deobfuscated crash reports.
- Discard incomplete Play edits when publishing fails.

CI:
- Update the Play publishing workflow to install and use the Google Play Developer API publishing script.